### PR TITLE
Add focus border options (focus border on tabs, size, translucency)

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -894,6 +894,17 @@
 			Expanding main editor window content to the title, if supported by [DisplayServer]. See [constant DisplayServer.WINDOW_FLAG_EXTEND_TO_TITLE].
 			Specific to the macOS platform.
 		</member>
+		<member name="interface/editor/focus_border_on_tabs" type="bool" setter="" getter="">
+			A focus border is drawn around tabs in the editor when they receive keyboard focus or are selected.
+		</member>
+		<member name="interface/editor/focus_border_type" type="int" setter="" getter="">
+			Chooses the focus border appearance using the following modes:
+			- [b]Off:[/b] The focus border is hidden entirely.
+			- [b]On:[/b] The focus border is 2px and is rendered with the current theme's accent color.
+			- [b]Translucent:[/b] The focus border is 2px and is rendered with the current theme's accent color in an opacity of 0.5.
+			- [b]On (Thin):[/b] The focus border is 1px and is rendered with the current theme's accent color.
+			- [b]Translucent (Thin):[/b] The focus border is 1px and is rendered with the current theme's accent color in an opacity of 0.5.
+		</member>
 		<member name="interface/editor/font_allow_msdf" type="bool" setter="" getter="">
 			If set to [code]true[/code], MSDF font rendering will be used for the visual shader graph editor. You may need to set this to [code]false[/code] when using a custom main font, as some fonts will look broken due to the use of self-intersecting outlines in their font data. Downloading the font from the font maker's official website as opposed to a service like Google Fonts can help resolve this issue.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -484,6 +484,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/check_for_updates", int(default_update_mode), "Disable Update Checks,Check Newest Preview,Check Newest Stable,Check Newest Patch"); // Uses EngineUpdateLabel::UpdateMode.
 	}
 
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/focus_border_on_tabs", true, "On,Off")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/focus_border_type", 1, "Off,On,Translucent,On (Thin),Translucent (Thin)")
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_native_file_dialogs", false, "", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -621,8 +621,38 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 
 			p_config.button_style_focus = p_config.button_style->duplicate();
 			p_config.button_style_focus->set_draw_center(false);
-			p_config.button_style_focus->set_border_width_all(Math::round(2 * MAX(1, EDSCALE)));
-			p_config.button_style_focus->set_border_color(p_config.accent_color);
+
+			int focus_border_type = (int)EDITOR_GET("interface/editor/focus_border_type");
+			int focus_border_width_on = Math::round(2 * MAX(1, EDSCALE));
+			int focus_border_width_thin = Math::round(1 * MAX(1, EDSCALE));
+			Color focus_border_color_translucent = Color(p_config.accent_color.r, p_config.accent_color.g, p_config.accent_color.b, 0.5);
+
+			switch (focus_border_type) {
+				case 0: // Off
+					p_config.button_style_focus->set_border_width_all(0);
+					p_config.button_style_focus->set_border_color(p_config.accent_color);
+					break;
+				case 1: // On (default)
+					p_config.button_style_focus->set_border_width_all(focus_border_width_on);
+					p_config.button_style_focus->set_border_color(p_config.accent_color);
+					break;
+				case 2: // Translucent
+					p_config.button_style_focus->set_border_width_all(focus_border_width_on);
+					p_config.button_style_focus->set_border_color(focus_border_color_translucent);
+					break;
+				case 3: // On - Thin
+					p_config.button_style_focus->set_border_width_all(focus_border_width_thin);
+					p_config.button_style_focus->set_border_color(p_config.accent_color);
+					break;
+				case 4: // Translucent - Thin
+					p_config.button_style_focus->set_border_width_all(focus_border_width_thin);
+					p_config.button_style_focus->set_border_color(focus_border_color_translucent);
+					break;
+				default: // In case of invalid value, set to On (case 1).
+					p_config.button_style_focus->set_border_width_all(focus_border_width_on);
+					p_config.button_style_focus->set_border_color(p_config.accent_color);
+					break;
+			}
 
 			p_config.button_style_pressed = p_config.button_style->duplicate();
 			p_config.button_style_pressed->set_bg_color(p_config.dark_color_1.darkened(0.125));
@@ -1159,6 +1189,10 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		style_tab_disabled->set_border_color(p_config.disabled_bg_color);
 
 		Ref<StyleBoxFlat> style_tab_focus = p_config.button_style_focus->duplicate();
+		if ((bool)EDITOR_GET("interface/editor/focus_border_on_tabs") == false) { // Off
+			style_tab_focus->set_border_width_all(0);
+			style_tab_focus->set_border_color(p_config.accent_color);
+		}
 
 		Ref<StyleBoxFlat> style_tabbar_background = make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0, p_config.corner_radius);
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
@@ -2945,6 +2979,8 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/font") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/main_font") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/code_font") ||
+				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/focus_border_type") ||
+				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/focus_border_on_tabs") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("editors/visual_editors") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/help") ||


### PR DESCRIPTION
This adds two settings in Editor > Editor Settings > Interface > Editor (focus_border_on_tabs and focus_border_type).  You can now disable focus borders on tabs entirely as well as minimize focus borders and alter their translucency, or turn them off entirely.

Focus border on tabs toggle:

https://github.com/user-attachments/assets/ac7e9b6a-b8d4-44b9-b593-2a2e06e1bb84

Changing focus border presentation:

https://github.com/user-attachments/assets/81a5994e-8da7-44e1-9ed1-10dd3fdc626b

