### PR TITLE
Add optional pck xor obfuscation

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -892,7 +892,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 
 	uint8_t hdr[4];
 	f->get_buffer(hdr, 4);
-	ERR_FAIL_COND_V_MSG((hdr[0] != 'E' || hdr[1] != 'C' || hdr[2] != 'F' || hdr[3] != 'G'), ERR_FILE_CORRUPT, "Corrupted header in binary project.binary (not ECFG).");
+	ERR_FAIL_COND_V_MSG((hdr[0] != 'E' || hdr[1] != 'C' || hdr[2] != 'F' || hdr[3] != 'G'), ERR_FILE_CORRUPT, "Corrupted header in binary project.binary (PACK_HEADER_MAGIC mismatch).");
 
 	uint32_t count = f->get_32();
 

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -39,6 +39,18 @@ def version_info_builder(target, source, env):
 """.format(**source[0].read())
         )
 
+        # Only define BLAZIUM_XOR_KEY if it's set and non-empty (enables XOR obfuscation)
+        version_data = source[0].read()
+        if version_data.get("blazium_xor_key"):
+            xor_key = version_data["blazium_xor_key"]
+            # Validate key length (must be exactly 1024 characters)
+            if len(xor_key) != 1024:
+                from SCons.Script import Exit
+
+                print(f"ERROR: blazium_xor_key must be exactly 1024 characters (got {len(xor_key)})")
+                Exit(1)
+            file.write('#define BLAZIUM_XOR_KEY "{}"\n'.format(xor_key))
+
 
 def version_hash_builder(target, source, env):
     with methods.generated_wrapper(str(target[0])) as file:

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -429,12 +429,16 @@ uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 		to_read = (int64_t)pf.size - (int64_t)pos;
 	}
 
+	uint64_t xor_offset = pos; // Save position for XOR de-obfuscation
 	pos += to_read;
 
 	if (to_read <= 0) {
 		return 0;
 	}
 	f->get_buffer(p_dst, to_read);
+
+	// Apply XOR de-obfuscation to file data using pack_xor_process (defined in file_access_pack.h).
+	pack_xor_process(p_dst, to_read, xor_offset);
 
 	return to_read;
 }

--- a/methods.py
+++ b/methods.py
@@ -155,6 +155,7 @@ def get_version_info(module_version_string="", silent=False):
         "external_sha": os.getenv("EXTERNAL_SHA", version.external_status),
         "mirror_list": os.getenv("MIRROR_LIST_URL", version.mirror_list),
         "version_url": os.getenv("VERSION_URL", version.version_url),
+        "blazium_xor_key": getattr(version, "blazium_xor_key", None),
     }
 
     # For dev snapshots (alpha, beta, RC, etc.) we do not commit status change to Git,

--- a/version.py
+++ b/version.py
@@ -14,10 +14,4 @@ external_status = "dev"
 external_sha = "876b290332ec6f2e6d173d08162a02aa7e6ca46d"
 mirror_list = "https://blazium.app/api/mirrorlist/"
 version_url = "https://blazium.app/api/versions-" + external_status + ".json"
-# XOR obfuscation key for pack files
-# Set to None or empty string to disable functionality.
-# To generate functional key, which has to be exactly
-# 1024 bytes, run the following and set the output as
-# a string value inside blazium_xor_key variable:
-# $ tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1024
-blazium_xor_key = None
+blazium_xor_key = ""

--- a/version.py
+++ b/version.py
@@ -14,3 +14,10 @@ external_status = "dev"
 external_sha = "876b290332ec6f2e6d173d08162a02aa7e6ca46d"
 mirror_list = "https://blazium.app/api/mirrorlist/"
 version_url = "https://blazium.app/api/versions-" + external_status + ".json"
+# XOR obfuscation key for pack files
+# Set to None or empty string to disable functionality.
+# To generate functional key, which has to be exactly
+# 1024 bytes, run the following and set the output as
+# a string value inside blazium_xor_key variable:
+# $ tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1024
+blazium_xor_key = None


### PR DESCRIPTION
Adds optional XOR obfuscation support for reading and writing PCK files.

This is not a fullproof way to protect an exported game developed in Blazium from being dumped and having its contents taken.  However, used in conjunction with using the AES256 encryption key and modifying the PACK_HEADER_MAGIC value on a per-project basis currently protects it from unauthorized inspection from tools like Godot PCK Tool and GDRETools.

The xor obfuscation is enabled at build time for the editor and templates. It is only utilized when a valid 1024 key is present in version.py and assigned to the variable blazium_xor_key.  By default, blazium_xor_key is set to an empty string and the feature is disabled.

You can generate a valid xor key by running the following:

`$ tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1024`

Therefore, an example of a valid setting in version.py is as follows:

`blazium_xor_key = "j1bchdxZvlrzX6nA6qck0mI6wqr6Gv6VvrbrltuDBNyOzzitdQfRhXLPzRjfuCHS0ZKS6bEieMrsPJ9iWHnJWEMdiktcZy0tCM9j1XQbwv9vY2zdH6q1uYJU1CRohNaD64oRGTXQU799xxDnIvY7DwxBBsxmJiUT9RiwgPVoq4SMqcYZtFXyKWZpeobdPWEF2quYelIqegRjm7Iz6lHxvRNzcY2yxEK9vSDHyyBmukuR7CR8PnfequIPMcLSlnky76kDDSGvz5nJPVkLnT4D5d9xr1z2OtwsF6Ib5OMrJg5XnTPLVnx2BQIZNbT0Dz3VeduIHcgTHMZlfEXmRs9AzroX8o227AyhOncTfg06iCcNh0k5OfAdknK4xfzFcxFLw8qYrYj8GWSYy5W0h9cI4ZA4392nbSVVt9pdMaHLjuHRsb9TY7jXHc5YuhNwNWmqti1VXTp6cu41jzlDht7xtJX2XPDzQMuh5GrCVKQMA2NiyL2JVriVj1pbn2D2N0bVntfmwPjyJ0fIaLQCIdM5NFb33lZUzNzoA7uePsqlk9o30tMF8tpJQ4pNo5aLHHMXLYTs2yCGJVmDMIFaWmRkSDc2wPe1aqiCATybw3fcPpxTLW3P1kuPtlxqyIdt8HLOBogrciXzhDAZHbgpQOWAVk7cGoTenSUB0QTjRti3Vm83lZVASsNgeDatvLgfN4Y68lbQVqj6fU2vYAneVdz3wDfKRzJ3NRf2AO8M18F7YDRSWSxliLxmVgAu5yrApiYO6aJjb35wZCQtKwsqKifHuOhliiGChW1XusRe1GhFKRckqHbZD5bBwrxlzYQgwXYpajYUwiPyIl2eXAeVICssIHw0gqXRwtywG24Wpvm202TWpTEG6Mx7xbUW5fY1tkwOPxiZrS4v7J0clj9x4ztGtu4OonDRYt6hcsLjfyPmloqovE0AK5UHd7fJM62j0ObzyIyj8wtwDfwi7sFs9A6oegONNcHD8YVF6sLOdoWCSQApK7IukLTsEl72Wixs9W0W"`

