### PR TITLE
Add remote debug client status section in editor UI's top toolbar

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -38,6 +38,13 @@ bool RemoteDebuggerPeerTCP::is_peer_connected() {
 	return connected;
 }
 
+String RemoteDebuggerPeerTCP::get_peer_host() {
+	if (tcp_client.is_valid() && tcp_client->get_status() == StreamPeerTCP::STATUS_CONNECTED) {
+		return String(tcp_client->get_connected_host());
+	}
+	return "";
+}
+
 bool RemoteDebuggerPeerTCP::has_message() {
 	return in_queue.size() > 0;
 }

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -44,6 +44,7 @@ protected:
 
 public:
 	virtual bool is_peer_connected() = 0;
+	virtual String get_peer_host() = 0;
 	virtual int get_max_message_size() const = 0;
 	virtual bool has_message() = 0;
 	virtual Error put_message(const Array &p_arr) = 0;
@@ -85,6 +86,7 @@ public:
 	Error connect_to_host(const String &p_host, uint16_t p_port);
 
 	bool is_peer_connected() override;
+	String get_peer_host() override;
 	int get_max_message_size() const override;
 	bool has_message() override;
 	Error put_message(const Array &p_arr) override;

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -962,6 +962,9 @@
 			If enabled, displays internal engine errors in toast notifications (toggleable by clicking the "bell" icon at the bottom of the editor). No matter the value of this setting, non-internal engine errors will always be visible in toast notifications.
 			The default [b]Auto[/b] value will only enable this if the editor was compiled with the [code]dev_build=yes[/code] SCons option (the default is [code]dev_build=no[/code]).
 		</member>
+		<member name="interface/editor/show_remote_debug_connection_status" type="bool" setter="" getter="">
+			If enabled, displays a new area in the top bar of the editor UI that shows the status of a remote debug session.  Hovering over this area will show a tooltip of the ip address.
+		</member>
 		<member name="interface/editor/show_update_spinner" type="int" setter="" getter="">
 			If enabled, displays an icon in the top-right corner of the editor that spins when the editor redraws a frame. This can be used to diagnose situations where the engine is constantly redrawing, which should be avoided as this increases CPU and GPU utilization for no good reason. To further troubleshoot these situations, start the editor with the [code]--debug-canvas-item-redraw[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
 			Consider enabling this if you are developing editor plugins to ensure they only make the editor redraw when required.

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1379,6 +1379,21 @@ void ScriptEditorDebugger::_resources_reimported(const PackedStringArray &p_reso
 	_put_msg("scene:reload_cached_files", msg);
 }
 
+String ScriptEditorDebugger::get_connected_host_ip() {
+	if (!peer.is_valid() || !peer->is_peer_connected()) {
+		return "";
+	}
+
+	// Try to cast to TCP peer to get the IP address
+	Ref<RemoteDebuggerPeerTCP> tcp_peer = peer;
+	if (tcp_peer.is_valid()) {
+		return tcp_peer->get_peer_host();
+	}
+
+	// For non-TCP peers (e.g., WebSocket), return a generic message
+	return "Connected";
+}
+
 int ScriptEditorDebugger::_get_node_path_cache(const NodePath &p_path) {
 	const int *r = node_path_cache.getptr(p_path);
 	if (r) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -330,6 +330,7 @@ public:
 	void debug_continue();
 	bool is_breaked() const { return threads_debugged.size() > 0; }
 	bool is_debuggable() const { return threads_debugged.size() > 0 && threads_debugged[debugging_thread_id].can_debug; }
+	String get_connected_host_ip();
 	bool is_session_active() { return peer.is_valid() && peer->is_peer_connected(); }
 	int get_remote_pid() const { return remote_pid; }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -331,6 +331,11 @@ private:
 	Control *right_menu_spacer = nullptr;
 	EditorTitleBar *title_bar = nullptr;
 	EditorRunBar *project_run_bar = nullptr;
+	HBoxContainer *debug_target_hb = nullptr;
+	Button *debug_target_label = nullptr;
+	Button *debug_target_status = nullptr;
+	bool debug_target_last_connected_state = false;
+	String debug_target_last_ip = "";
 	HBoxContainer *right_menu_hb = nullptr;
 
 	// Spacers to center 2D / 3D / Script buttons.
@@ -719,6 +724,8 @@ private:
 
 	void _update_main_menu_type();
 	void _add_to_main_menu(const String &p_name, PopupMenu *p_menu);
+
+	void _update_debug_target_status();
 
 protected:
 	friend class FileSystemDock;

--- a/editor/run/editor_run_native.cpp
+++ b/editor/run/editor_run_native.cpp
@@ -59,7 +59,7 @@ void EditorRunNative::_notification(int p_what) {
 					const int device_count = MIN(eep->get_options_count(), 9000);
 					String error;
 					if (device_count > 0 && preset->is_runnable()) {
-						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
+						popup->add_icon_item(eep->get_run_icon(), preset->get_name(), -1);
 						popup->set_item_disabled(-1, true);
 						for (int j = 0; j < device_count; j++) {
 							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), EditorExport::encode_platform_device_id(platform_idx, j));

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -517,6 +517,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/accept_dialog_cancel_ok_buttons", 0,
 			vformat("Auto (%s),Cancel First,OK First", DisplayServer::get_singleton()->get_swap_cancel_ok() ? "OK First" : "Cancel First"),
 			PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/show_remote_debug_connection_status", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 #ifdef DEV_ENABLED
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/show_internal_errors_in_toast_notifications", 0, "Auto (Enabled),Enabled,Disabled")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/show_update_spinner", 0, "Auto (Enabled),Enabled,Disabled")

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -61,6 +61,13 @@ bool RemoteDebuggerPeerWebSocket::is_peer_connected() {
 	return ws_peer.is_valid() && (ws_peer->get_ready_state() == WebSocketPeer::STATE_OPEN || ws_peer->get_ready_state() == WebSocketPeer::STATE_CONNECTING);
 }
 
+String RemoteDebuggerPeerWebSocket::get_peer_host() {
+	if (ws_peer.is_valid() && ws_peer->get_ready_state() == WebSocketPeer::STATE_OPEN) {
+		return String(ws_peer->get_connected_host());
+	}
+	return "";
+}
+
 void RemoteDebuggerPeerWebSocket::poll() {
 	ERR_FAIL_COND(ws_peer.is_null());
 	ws_peer->poll();

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -49,6 +49,7 @@ public:
 	Error connect_to_host(const String &p_uri);
 
 	bool is_peer_connected() override;
+	String get_peer_host() override;
 	int get_max_message_size() const override;
 	bool has_message() override;
 	Error put_message(const Array &p_arr) override;


### PR DESCRIPTION
This feature adds a section on the editor UI's top toolbar that shows the current status of a remote debug session from a client running either remotely or locally.  

It is ideally meant to be used in conjunction with the following settings:

1) Debug > Keep Debug Server Open
2) Enabling remote target exports via ssh (see Project > Export > Add (windows, linuxbsd, macos), toggle on Runnable, and toggling SSH Remote Deploy to on)
3) Setting Remote Host to your LAN routable ip (not localhost/127.0.0.1) (see Editor > Editor Settings > Network > Debug > Remote Host).

This PR attempts to easily relay the status of the remote debug session at a glance to the developer.  

Windows in particular has a few peculiarities when it comes to using it as a target for a remote deploy.  OpenSSH, Windows policies for script execution, and firewall settings all need to be modified to get it to work and Windows updates periodically revert these modifications.  This is problematic when you're expecting to hit breakpoints and it never occurs because the remote debug session never actually opened.  So it is useful to have an indication whether or not a remote debug session is active or not.

This feature can be toggled on and off, so it can be hidden entirely from developers who do not have need of it.


https://github.com/user-attachments/assets/cd007486-89aa-4a2d-b8c4-f757990e180f


