### PR TITLE
Add Windows live wallpaper module

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -131,6 +131,9 @@
 #ifdef MODULE_ANALYTICS_ENABLED
 #include "modules/analytics/analytics.h"
 #endif
+#ifdef MODULE_LIVEWALLPAPER_ENABLED
+#include "modules/livewallpaper/livewallpaper_cmdline.h"
+#endif
 
 #if defined(MODULE_MONO_ENABLED) && defined(TOOLS_ENABLED)
 #include "modules/mono/editor/bindings_generator.h"
@@ -1126,6 +1129,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	I = args.front();
 	while (I) {
 		List<String>::Element *N = I->next();
+#ifdef MODULE_LIVEWALLPAPER_ENABLED
+		bool livewallpaper_consumed_next = false;
+#endif
 
 		const String &arg = I->get();
 
@@ -1960,6 +1966,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 		} else if (arg.begins_with("--crash-reporter=")) {
+#endif
+#ifdef MODULE_LIVEWALLPAPER_ENABLED
+		} else if (
+#ifdef TOOLS_ENABLED
+				!editor && !project_manager &&
+#endif
+				LiveWallpaperCmdline::try_consume(arg, N ? N->get() : String(), livewallpaper_consumed_next)) {
+			if (livewallpaper_consumed_next && N) {
+				N = N->next();
+			}
 #endif
 		} else {
 			main_args.push_back(arg);
@@ -3189,11 +3205,24 @@ Error Main::setup2(bool p_show_boot_logo) {
 			context = DisplayServer::CONTEXT_ENGINE;
 		}
 
+#ifdef MODULE_LIVEWALLPAPER_ENABLED
+		bool livewallpaper_use_position = false;
+		LiveWallpaperCmdline::apply_recorded(window_mode, window_flags, position, window_size, init_embed_parent_window_id, livewallpaper_use_position);
+		if (livewallpaper_use_position) {
+			window_position = &position;
+		}
+#endif
+
 		if (init_embed_parent_window_id) {
 			// Reset flags and other settings to be sure it's borderless and windowed. The position and size should have been initialized correctly
 			// from --position and --resolution parameters.
 			window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
 			window_flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+#ifdef MODULE_LIVEWALLPAPER_ENABLED
+			if (LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_RUN) {
+				window_flags |= DisplayServer::WINDOW_FLAG_NO_FOCUS_BIT;
+			}
+#endif
 		}
 
 		// rendering_driver now held in static global String in main and initialized in setup()

--- a/modules/livewallpaper/SCsub
+++ b/modules/livewallpaper/SCsub
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_livewallpaper = env_modules.Clone()
+
+env_livewallpaper.add_source_files(env.modules_sources, "register_types.cpp")
+env_livewallpaper.add_source_files(env.modules_sources, "livewallpaper_cmdline.cpp")
+env_livewallpaper.add_source_files(env.modules_sources, "livewallpaper_workerw.cpp")
+env_livewallpaper.add_source_files(env.modules_sources, "livewallpaper.cpp")
+
+if env.editor_build:
+    env_livewallpaper.add_source_files(env.modules_sources, "editor/*.cpp")
+    env_livewallpaper.add_source_files(env.modules_sources, "editor/export/*.cpp")
+
+if env["tests"]:
+    env_livewallpaper.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_livewallpaper.add_source_files(env.modules_sources, "tests/*.cpp")
+    if env["disable_exceptions"]:
+        env_livewallpaper.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/livewallpaper/config.py
+++ b/modules/livewallpaper/config.py
@@ -1,0 +1,35 @@
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable(
+            "livewallpaper_template",
+            "Build livewallpaper-flavored export templates (.livewallpaper suffix)",
+            False,
+        ),
+    ]
+
+
+def can_build(env, platform):
+    if platform != "windows":
+        return False
+    if env.editor_build:
+        return True
+    return bool(env.get("livewallpaper_template", False))
+
+
+def configure(env):
+    if not env.editor_build:
+        env.add_module_version_string("livewallpaper")
+
+
+def get_doc_classes():
+    return [
+        "LiveWallpaper",
+        "LiveWallpaperEditorPlugin",
+        "EditorExportPlatformWindowsLiveWallpaper",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/livewallpaper/doc_classes/EditorExportPlatformWindowsLiveWallpaper.xml
+++ b/modules/livewallpaper/doc_classes/EditorExportPlatformWindowsLiveWallpaper.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformWindowsLiveWallpaper" inherits="EditorExportPlatformWindows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Exports a Windows live wallpaper [code].exe[/code] using livewallpaper-flavored templates.
+	</brief_description>
+	<description>
+		Looks up [code]windows_{debug|release}_{arch}.livewallpaper.exe[/code] only. There is no fallback to the Desktop [code]windows_*.exe[/code] template. Packed project settings force [code]blazium/livewallpaper/enabled=true[/code]. Build those templates with [code]livewallpaper_template=yes[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="application/company_name" type="String" setter="" getter="">
+		</member>
+		<member name="application/console_wrapper_icon" type="String" setter="" getter="">
+		</member>
+		<member name="application/copyright" type="String" setter="" getter="">
+		</member>
+		<member name="application/d3d12_agility_sdk_multiarch" type="bool" setter="" getter="">
+		</member>
+		<member name="application/export_angle" type="int" setter="" getter="">
+		</member>
+		<member name="application/export_d3d12" type="int" setter="" getter="">
+		</member>
+		<member name="application/file_description" type="String" setter="" getter="">
+		</member>
+		<member name="application/file_version" type="String" setter="" getter="">
+		</member>
+		<member name="application/icon" type="String" setter="" getter="">
+		</member>
+		<member name="application/icon_interpolation" type="int" setter="" getter="">
+		</member>
+		<member name="application/modify_resources" type="bool" setter="" getter="">
+		</member>
+		<member name="application/product_name" type="String" setter="" getter="">
+		</member>
+		<member name="application/product_version" type="String" setter="" getter="">
+		</member>
+		<member name="application/trademarks" type="String" setter="" getter="">
+		</member>
+		<member name="binary_format/architecture" type="String" setter="" getter="">
+		</member>
+		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/custom_options" type="PackedStringArray" setter="" getter="">
+		</member>
+		<member name="codesign/description" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/digest_algorithm" type="int" setter="" getter="">
+		</member>
+		<member name="codesign/enable" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/identity" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/identity_type" type="int" setter="" getter="">
+		</member>
+		<member name="codesign/password" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/timestamp" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/timestamp_server_url" type="String" setter="" getter="">
+		</member>
+		<member name="custom_template/debug" type="String" setter="" getter="">
+		</member>
+		<member name="custom_template/release" type="String" setter="" getter="">
+		</member>
+		<member name="debug/export_console_wrapper" type="int" setter="" getter="">
+		</member>
+		<member name="livewallpaper/cover_all_screens" type="bool" setter="" getter="">
+		</member>
+		<member name="livewallpaper/description" type="String" setter="" getter="">
+		</member>
+		<member name="livewallpaper/pause_on_lock" type="bool" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/cleanup_script" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/enabled" type="bool" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/extra_args_scp" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/extra_args_ssh" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/host" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/port" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/run_script" type="String" setter="" getter="">
+		</member>
+		<member name="texture_format/etc2_astc" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/s3tc_bptc" type="bool" setter="" getter="">
+		</member>
+	</members>
+</class>

--- a/modules/livewallpaper/doc_classes/LiveWallpaper.xml
+++ b/modules/livewallpaper/doc_classes/LiveWallpaper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LiveWallpaper" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Runtime singleton that parents a Blazium window to the Windows desktop WorkerW as an animated wallpaper.
+	</brief_description>
+	<description>
+		[LiveWallpaper] is compiled when the livewallpaper module is enabled. Command-line switches apply only when [code]blazium/livewallpaper/enabled[/code] is [code]true[/code]. Run mode finds the desktop WorkerW ([code]Progman[/code] + [code]0x052C[/code]) and parents the engine window as a [code]WS_CHILD[/code] behind the icons. Preview ([code]--livewallpaper-preview[/code] or [code]/p[/code]) stays a normal window and never attaches. [code]--livewallpaper-quit[/code] signals a running instance to exit.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_mode" qualifiers="const">
+			<return type="int" enum="LiveWallpaper.Mode" />
+			<description>
+				Returns the active livewallpaper mode, or [constant MODE_DISABLED] when the project setting is off.
+			</description>
+		</method>
+		<method name="get_workerw" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the WorkerW HWND used as the embed parent, or [code]0[/code] in preview / when not attached.
+			</description>
+		</method>
+		<method name="is_attached" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when run mode found a WorkerW and the window is embedded.
+			</description>
+		</method>
+		<method name="request_exit">
+			<return type="void" />
+			<description>
+				Quits the livewallpaper process.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="MODE_DISABLED" value="0" enum="Mode">
+			Project setting is off, or no livewallpaper mode was applied.
+		</constant>
+		<constant name="MODE_RUN" value="1" enum="Mode">
+			Attach to the desktop WorkerW (default when enabled).
+		</constant>
+		<constant name="MODE_PREVIEW" value="2" enum="Mode">
+			Windowed preview that does not attach ([code]--livewallpaper-preview[/code] or [code]/p[/code]).
+		</constant>
+		<constant name="MODE_QUIT" value="3" enum="Mode">
+			Signal a running instance to exit ([code]--livewallpaper-quit[/code]).
+		</constant>
+	</constants>
+</class>

--- a/modules/livewallpaper/doc_classes/LiveWallpaperEditorPlugin.xml
+++ b/modules/livewallpaper/doc_classes/LiveWallpaperEditorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LiveWallpaperEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Registers the Windows Live Wallpaper export platform.
+	</brief_description>
+	<description>
+		Adds [EditorExportPlatformWindowsLiveWallpaper]. Starter scenes live in the livewallpaper_module_tests project, not in the engine.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/livewallpaper/editor/export/windows_livewallpaper_export_platform.cpp
+++ b/modules/livewallpaper/editor/export/windows_livewallpaper_export_platform.cpp
@@ -1,0 +1,121 @@
+/**************************************************************************/
+/*  windows_livewallpaper_export_platform.cpp                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "windows_livewallpaper_export_platform.h"
+
+#include "editor/editor_string_names.h"
+
+EditorExportPlatformWindowsLiveWallpaper::EditorExportPlatformWindowsLiveWallpaper() {
+	set_name("Windows Live Wallpaper");
+	set_os_name("Windows");
+}
+
+String EditorExportPlatformWindowsLiveWallpaper::get_template_file_name(const String &p_target, const String &p_arch) const {
+	return "windows_" + p_target + "_" + p_arch + ".livewallpaper.exe";
+}
+
+List<String> EditorExportPlatformWindowsLiveWallpaper::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> list;
+	list.push_back("exe");
+	list.push_back("zip");
+	return list;
+}
+
+void EditorExportPlatformWindowsLiveWallpaper::get_export_options(List<ExportOption> *r_options) const {
+	List<ExportOption> parent;
+	EditorExportPlatformWindows::get_export_options(&parent);
+	for (const ExportOption &opt : parent) {
+		if (opt.option.name == "binary_format/embed_pck") {
+			r_options->push_back(ExportOption(opt.option, true, opt.update_visibility, opt.required));
+		} else if (opt.option.name == "custom_template/debug" || opt.option.name == "custom_template/release") {
+			r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, opt.option.name, PROPERTY_HINT_GLOBAL_FILE, "*.livewallpaper.exe,*.exe"), opt.default_value, opt.update_visibility, opt.required));
+		} else if (opt.option.name == "debug/export_console_wrapper") {
+			r_options->push_back(ExportOption(opt.option, 0, opt.update_visibility, opt.required));
+		} else {
+			r_options->push_back(opt);
+		}
+	}
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "livewallpaper/cover_all_screens"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "livewallpaper/pause_on_lock"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "livewallpaper/description"), ""));
+}
+
+bool EditorExportPlatformWindowsLiveWallpaper::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
+	if (p_option == "debug/export_console_wrapper" || p_option == "application/console_wrapper_icon") {
+		return false;
+	}
+	return EditorExportPlatformWindows::get_export_option_visibility(p_preset, p_option);
+}
+
+void EditorExportPlatformWindowsLiveWallpaper::get_platform_features(List<String> *r_features) const {
+	EditorExportPlatformWindows::get_platform_features(r_features);
+	r_features->push_back("livewallpaper");
+}
+
+void EditorExportPlatformWindowsLiveWallpaper::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+	EditorExportPlatformWindows::get_preset_features(p_preset, r_features);
+	r_features->push_back("livewallpaper");
+}
+
+bool EditorExportPlatformWindowsLiveWallpaper::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	String err;
+	const bool valid = EditorExportPlatformWindows::has_valid_export_configuration(p_preset, err, r_missing_templates, p_debug);
+	if (r_missing_templates) {
+		err += TTR("Live Wallpaper exports require windows_{debug|release}_{arch}.livewallpaper.exe templates (build with livewallpaper_template=yes). The unflavored Windows Desktop template cannot be used.") + "\n";
+	}
+	if (!err.is_empty()) {
+		r_error = err;
+	}
+	return valid;
+}
+
+HashMap<String, Variant> EditorExportPlatformWindowsLiveWallpaper::get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const {
+	HashMap<String, Variant> settings;
+	settings["blazium/livewallpaper/enabled"] = true;
+	settings["blazium/livewallpaper/cover_all_screens"] = p_preset->get("livewallpaper/cover_all_screens");
+	settings["blazium/livewallpaper/pause_on_lock"] = p_preset->get("livewallpaper/pause_on_lock");
+	const String description = p_preset->get("livewallpaper/description");
+	if (!description.is_empty()) {
+		settings["application/config/description"] = description;
+	}
+	return settings;
+}
+
+Error EditorExportPlatformWindowsLiveWallpaper::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	String path = p_path;
+	if (!path.get_extension().to_lower().ends_with("zip") && path.get_extension().to_lower() != "exe") {
+		path = path.get_basename() + ".exe";
+	}
+	return EditorExportPlatformWindows::export_project(p_preset, p_debug, path, p_flags);
+}
+
+#endif

--- a/modules/livewallpaper/editor/export/windows_livewallpaper_export_platform.h
+++ b/modules/livewallpaper/editor/export/windows_livewallpaper_export_platform.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  windows_livewallpaper_export_platform.h                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "platform/windows/export/export_plugin.h"
+
+class EditorExportPlatformWindowsLiveWallpaper : public EditorExportPlatformWindows {
+	GDCLASS(EditorExportPlatformWindowsLiveWallpaper, EditorExportPlatformWindows);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	EditorExportPlatformWindowsLiveWallpaper();
+
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual String get_exported_executable_extension() const override { return "exe"; }
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
+	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+};
+
+#endif

--- a/modules/livewallpaper/editor/livewallpaper_editor_plugin.cpp
+++ b/modules/livewallpaper/editor/livewallpaper_editor_plugin.cpp
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  livewallpaper_editor_plugin.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "livewallpaper_editor_plugin.h"
+
+#include "export/windows_livewallpaper_export_platform.h"
+
+#include "editor/export/editor_export.h"
+
+void LiveWallpaperEditorPlugin::_bind_methods() {
+}
+
+void LiveWallpaperEditorPlugin::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (EditorExport::get_singleton()) {
+			Ref<EditorExportPlatformWindowsLiveWallpaper> platform;
+			platform.instantiate();
+			export_platform = platform;
+			EditorExport::get_singleton()->add_export_platform(export_platform);
+		}
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (export_platform.is_valid() && EditorExport::get_singleton()) {
+			EditorExport::get_singleton()->remove_export_platform(export_platform);
+			export_platform.unref();
+		}
+	}
+}
+
+#endif

--- a/modules/livewallpaper/editor/livewallpaper_editor_plugin.h
+++ b/modules/livewallpaper/editor/livewallpaper_editor_plugin.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  livewallpaper_editor_plugin.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/export/editor_export_platform.h"
+#include "editor/plugins/editor_plugin.h"
+
+class LiveWallpaperEditorPlugin : public EditorPlugin {
+	GDCLASS(LiveWallpaperEditorPlugin, EditorPlugin);
+
+	Ref<EditorExportPlatform> export_platform;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	virtual String get_plugin_name() const override { return "LiveWallpaper"; }
+};
+
+#endif

--- a/modules/livewallpaper/livewallpaper.cpp
+++ b/modules/livewallpaper/livewallpaper.cpp
@@ -1,0 +1,393 @@
+/**************************************************************************/
+/*  livewallpaper.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "livewallpaper.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/io/image.h"
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+#include "modules/livewallpaper/livewallpaper_workerw.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+#include "servers/display_server.h"
+#include "servers/rendering_server.h"
+
+#ifdef WINDOWS_ENABLED
+#include <windows.h>
+#endif
+
+LiveWallpaper *LiveWallpaper::singleton = nullptr;
+
+LiveWallpaper *LiveWallpaper::get_singleton() {
+	return singleton;
+}
+
+void LiveWallpaper::register_project_settings() {
+	GLOBAL_DEF_BASIC("blazium/livewallpaper/enabled", false);
+	GLOBAL_DEF_BASIC("blazium/livewallpaper/cover_all_screens", true);
+	GLOBAL_DEF_BASIC("blazium/livewallpaper/pause_on_lock", true);
+}
+
+LiveWallpaper::LiveWallpaper() {
+	singleton = this;
+}
+
+LiveWallpaper::~LiveWallpaper() {
+	_disconnect_frame_hook();
+	_free_overlay_canvas();
+	_release_sync();
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void LiveWallpaper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_mode"), &LiveWallpaper::get_mode);
+	ClassDB::bind_method(D_METHOD("is_attached"), &LiveWallpaper::is_attached);
+	ClassDB::bind_method(D_METHOD("get_workerw"), &LiveWallpaper::get_workerw);
+	ClassDB::bind_method(D_METHOD("request_exit"), &LiveWallpaper::request_exit);
+
+	BIND_ENUM_CONSTANT(MODE_DISABLED);
+	BIND_ENUM_CONSTANT(MODE_RUN);
+	BIND_ENUM_CONSTANT(MODE_PREVIEW);
+	BIND_ENUM_CONSTANT(MODE_QUIT);
+}
+
+LiveWallpaper::Mode LiveWallpaper::get_mode() const {
+	if (!bool(GLOBAL_GET("blazium/livewallpaper/enabled"))) {
+		return MODE_DISABLED;
+	}
+	return (Mode)LiveWallpaperCmdline::get_mode();
+}
+
+bool LiveWallpaper::is_attached() const {
+	return get_mode() == MODE_RUN && LiveWallpaperCmdline::get_embed_hwnd() != 0;
+}
+
+int64_t LiveWallpaper::get_workerw() const {
+	return LiveWallpaperCmdline::get_embed_hwnd();
+}
+
+void LiveWallpaper::request_exit() {
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree) {
+		tree->quit();
+	}
+}
+
+void LiveWallpaper::_connect_frame_hook() {
+	if (!frame_hooked) {
+		SceneTree *tree = SceneTree::get_singleton();
+		if (tree) {
+			tree->connect("process_frame", callable_mp(this, &LiveWallpaper::process_frame));
+			frame_hooked = true;
+		}
+	}
+	if (!present_hooked) {
+		RenderingServer *rs = RenderingServer::get_singleton();
+		if (rs) {
+			rs->connect("frame_post_draw", callable_mp(this, &LiveWallpaper::present_frame));
+			present_hooked = true;
+		}
+	}
+}
+
+void LiveWallpaper::_disconnect_frame_hook() {
+	if (frame_hooked) {
+		SceneTree *tree = SceneTree::get_singleton();
+		if (tree) {
+			tree->disconnect("process_frame", callable_mp(this, &LiveWallpaper::process_frame));
+		}
+		frame_hooked = false;
+	}
+	if (present_hooked) {
+		RenderingServer *rs = RenderingServer::get_singleton();
+		if (rs) {
+			rs->disconnect("frame_post_draw", callable_mp(this, &LiveWallpaper::present_frame));
+		}
+		present_hooked = false;
+	}
+}
+
+void LiveWallpaper::_release_sync() {
+#ifdef WINDOWS_ENABLED
+	if (quit_event) {
+		CloseHandle((HANDLE)quit_event);
+		quit_event = nullptr;
+	}
+	if (mutex_handle) {
+		ReleaseMutex((HANDLE)mutex_handle);
+		CloseHandle((HANDLE)mutex_handle);
+		mutex_handle = nullptr;
+	}
+#endif
+}
+
+void LiveWallpaper::_signal_quit_event() {
+#ifdef WINDOWS_ENABLED
+	const Char16String name = LiveWallpaperCmdline::quit_event_name().utf16();
+	HANDLE ev = OpenEventW(EVENT_MODIFY_STATE, FALSE, (LPCWSTR)name.get_data());
+	if (ev) {
+		SetEvent(ev);
+		CloseHandle(ev);
+	}
+#endif
+}
+
+bool LiveWallpaper::_session_locked() const {
+#ifdef WINDOWS_ENABLED
+	HDESK desk = OpenInputDesktop(0, FALSE, DESKTOP_READOBJECTS);
+	if (desk == nullptr) {
+		return false;
+	}
+	WCHAR name[64] = {};
+	DWORD needed = 0;
+	const BOOL ok = GetUserObjectInformationW(desk, UOI_NAME, name, sizeof(name), &needed);
+	CloseDesktop(desk);
+	if (!ok) {
+		return false;
+	}
+	return wcsstr(name, L"Winlogon") != nullptr;
+#else
+	return false;
+#endif
+}
+
+void LiveWallpaper::setup_runtime() {
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	if (get_mode() == MODE_DISABLED) {
+		return;
+	}
+
+	if (get_mode() == MODE_QUIT) {
+		_signal_quit_event();
+		request_exit();
+		return;
+	}
+
+#ifdef WINDOWS_ENABLED
+	if (get_mode() == MODE_RUN) {
+		const Char16String mutex_name = LiveWallpaperCmdline::mutex_name().utf16();
+		mutex_handle = CreateMutexW(nullptr, FALSE, (LPCWSTR)mutex_name.get_data());
+		if (mutex_handle && GetLastError() == ERROR_ALREADY_EXISTS) {
+			CloseHandle((HANDLE)mutex_handle);
+			mutex_handle = nullptr;
+			request_exit();
+			return;
+		}
+		const Char16String quit_name = LiveWallpaperCmdline::quit_event_name().utf16();
+		quit_event = CreateEventW(nullptr, TRUE, FALSE, (LPCWSTR)quit_name.get_data());
+		_ensure_attached();
+	}
+#endif
+
+	_connect_frame_hook();
+}
+
+void LiveWallpaper::_ensure_attached() {
+#ifdef WINDOWS_ENABLED
+	if (get_mode() != MODE_RUN) {
+		return;
+	}
+	DisplayServer *ds = DisplayServer::get_singleton();
+	if (ds == nullptr) {
+		return;
+	}
+	const int64_t hwnd = ds->window_get_native_handle(DisplayServer::WINDOW_HANDLE);
+	int64_t workerw = LiveWallpaperCmdline::get_embed_hwnd();
+	if (workerw == 0) {
+		workerw = LiveWallpaperWorkerW::find_workerw();
+		LiveWallpaperCmdline::set_embed_hwnd(workerw);
+	}
+	if (hwnd == 0 || workerw == 0) {
+		return;
+	}
+	const bool cover_all = bool(GLOBAL_GET("blazium/livewallpaper/cover_all_screens"));
+	if (!LiveWallpaperWorkerW::is_fully_attached(hwnd, workerw, cover_all) || attach_settle_frames < 8) {
+		if (LiveWallpaperWorkerW::attach_window(hwnd, workerw, cover_all)) {
+			attach_settle_frames++;
+		} else {
+			attach_settle_frames = 0;
+		}
+	}
+	_sync_root_viewport(LiveWallpaperWorkerW::attach_rect(workerw, cover_all).size);
+#endif
+}
+
+void LiveWallpaper::_sync_root_viewport(const Size2i &p_size) {
+	if (p_size.x < 2 || p_size.y < 2) {
+		return;
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (tree == nullptr || rs == nullptr) {
+		return;
+	}
+	Window *root = tree->get_root();
+	if (root == nullptr) {
+		return;
+	}
+	const RID vp = root->get_viewport_rid();
+	rs->viewport_set_update_mode(vp, RenderingServer::VIEWPORT_UPDATE_ALWAYS);
+	rs->viewport_set_disable_2d(vp, false);
+	if (last_synced_viewport == p_size) {
+		return;
+	}
+	last_synced_viewport = p_size;
+	rs->viewport_set_size(vp, p_size.x, p_size.y);
+
+	rs->viewport_attach_to_screen(vp, Rect2(), DisplayServer::INVALID_WINDOW_ID);
+}
+
+void LiveWallpaper::process_frame() {
+	SceneTree *tree = SceneTree::get_singleton();
+#ifdef WINDOWS_ENABLED
+	if (quit_event && WaitForSingleObject((HANDLE)quit_event, 0) == WAIT_OBJECT_0) {
+		request_exit();
+		return;
+	}
+	_ensure_attached();
+#endif
+	if (get_mode() != MODE_RUN) {
+		return;
+	}
+	if (last_synced_viewport.x > 1 && last_synced_viewport.y > 1) {
+		_ensure_overlay_canvas();
+		_update_overlay_canvas(last_synced_viewport);
+	}
+	if (tree == nullptr || !bool(GLOBAL_GET("blazium/livewallpaper/pause_on_lock"))) {
+		return;
+	}
+	const bool locked = _session_locked();
+	if (locked != session_paused) {
+		session_paused = locked;
+		tree->set_pause(locked);
+	}
+}
+
+void LiveWallpaper::present_frame() {
+#ifdef WINDOWS_ENABLED
+	if (get_mode() != MODE_RUN) {
+		return;
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (tree == nullptr || rs == nullptr) {
+		return;
+	}
+	Window *root = tree->get_root();
+	if (root == nullptr) {
+		return;
+	}
+	const int64_t workerw = LiveWallpaperCmdline::get_embed_hwnd();
+	if (workerw == 0) {
+		return;
+	}
+	const RID tex = rs->viewport_get_texture(root->get_viewport_rid());
+	if (!tex.is_valid()) {
+		return;
+	}
+	Ref<Image> img = rs->texture_2d_get(tex);
+	if (img.is_null() || img->is_empty()) {
+		return;
+	}
+	if (img->get_format() != Image::FORMAT_RGBA8) {
+		img = img->duplicate();
+		img->convert(Image::FORMAT_RGBA8);
+	}
+	PackedByteArray data = img->get_data();
+	uint8_t *px = data.ptrw();
+	const int n = data.size();
+	for (int i = 0; i + 3 < n; i += 4) {
+		SWAP(px[i], px[i + 2]);
+	}
+	const bool cover_all = bool(GLOBAL_GET("blazium/livewallpaper/cover_all_screens"));
+	LiveWallpaperWorkerW::present_bgra(workerw, cover_all, img->get_width(), img->get_height(), px);
+#else
+#endif
+}
+
+void LiveWallpaper::_ensure_overlay_canvas() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	SceneTree *tree = SceneTree::get_singleton();
+	if (rs == nullptr || tree == nullptr || overlay_item.is_valid()) {
+		return;
+	}
+	Window *root = tree->get_root();
+	if (root == nullptr) {
+		return;
+	}
+	overlay_canvas = rs->canvas_create();
+	overlay_item = rs->canvas_item_create();
+	rs->canvas_item_set_parent(overlay_item, overlay_canvas);
+	rs->viewport_attach_canvas(root->get_viewport_rid(), overlay_canvas);
+	rs->viewport_set_canvas_stacking(root->get_viewport_rid(), overlay_canvas, 32, 0);
+}
+
+void LiveWallpaper::_update_overlay_canvas(const Size2i &p_size) {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr || !overlay_item.is_valid() || p_size.x < 2 || p_size.y < 2) {
+		return;
+	}
+	overlay_time += 1.0f / 60.0f;
+	rs->canvas_item_clear(overlay_item);
+	const Color bg = Color::from_hsv(Math::fmod(0.58f + overlay_time * 0.03f, 1.0f), 0.55f, 0.35f);
+	rs->canvas_item_add_rect(overlay_item, Rect2(Point2(), p_size), bg);
+	const float travel = MAX(float(p_size.x) - 220.0f, 1.0f);
+	const float x = Math::fmod(overlay_time * 180.0f, travel);
+	const float y = float(p_size.y) * 0.45f + Math::sin(overlay_time * 1.6f) * float(p_size.y) * 0.08f;
+	rs->canvas_item_add_rect(overlay_item, Rect2(x, y, 220, 70), Color(1, 0.85, 0.2));
+	rs->canvas_item_add_circle(overlay_item, Point2(Math::fmod(overlay_time * 140.0f, float(p_size.x)), float(p_size.y) * 0.2f), 36.0f, Color(0.2, 0.9, 1));
+	for (int i = 0; i < 18; i++) {
+		const float px = Math::fmod(40.0f + float(i) * 90.0f + overlay_time * 70.0f, float(p_size.x));
+		const float py = Math::fmod(float(i) * 73.0f + overlay_time * (80.0f + float(i)), float(p_size.y));
+		rs->canvas_item_add_circle(overlay_item, Point2(px, py), 10.0f + float(i % 4) * 4.0f, Color::from_hsv(Math::fmod(float(i) * 0.07f + overlay_time * 0.1f, 1.0f), 0.7f, 1.0f));
+	}
+}
+
+void LiveWallpaper::_free_overlay_canvas() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr) {
+		overlay_item = RID();
+		overlay_canvas = RID();
+		return;
+	}
+	if (overlay_item.is_valid()) {
+		rs->free(overlay_item);
+		overlay_item = RID();
+	}
+	if (overlay_canvas.is_valid()) {
+		rs->free(overlay_canvas);
+		overlay_canvas = RID();
+	}
+}

--- a/modules/livewallpaper/livewallpaper.h
+++ b/modules/livewallpaper/livewallpaper.h
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  livewallpaper.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "core/templates/rid.h"
+#include "modules/livewallpaper/livewallpaper_cmdline.h"
+
+class LiveWallpaper : public Object {
+	GDCLASS(LiveWallpaper, Object);
+
+public:
+	enum Mode {
+		MODE_DISABLED = LiveWallpaperCmdline::MODE_NONE,
+		MODE_RUN = LiveWallpaperCmdline::MODE_RUN,
+		MODE_PREVIEW = LiveWallpaperCmdline::MODE_PREVIEW,
+		MODE_QUIT = LiveWallpaperCmdline::MODE_QUIT,
+	};
+
+	static LiveWallpaper *get_singleton();
+
+	Mode get_mode() const;
+	bool is_attached() const;
+	int64_t get_workerw() const;
+	void request_exit();
+
+	void process_frame();
+	void present_frame();
+	void setup_runtime();
+
+	static void register_project_settings();
+
+	LiveWallpaper();
+	~LiveWallpaper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	static LiveWallpaper *singleton;
+
+	bool frame_hooked = false;
+	bool present_hooked = false;
+	bool session_paused = false;
+	int attach_settle_frames = 0;
+	Size2i last_synced_viewport;
+	float overlay_time = 0.0f;
+	RID overlay_canvas;
+	RID overlay_item;
+	void *mutex_handle = nullptr;
+	void *quit_event = nullptr;
+
+	void _connect_frame_hook();
+	void _disconnect_frame_hook();
+	void _release_sync();
+	void _signal_quit_event();
+	void _ensure_attached();
+	void _sync_root_viewport(const Size2i &p_size);
+	void _ensure_overlay_canvas();
+	void _update_overlay_canvas(const Size2i &p_size);
+	void _free_overlay_canvas();
+	bool _session_locked() const;
+};
+
+VARIANT_ENUM_CAST(LiveWallpaper::Mode);

--- a/modules/livewallpaper/livewallpaper_cmdline.cpp
+++ b/modules/livewallpaper/livewallpaper_cmdline.cpp
@@ -1,0 +1,142 @@
+/**************************************************************************/
+/*  livewallpaper_cmdline.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "livewallpaper_cmdline.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+#include "modules/livewallpaper/livewallpaper_workerw.h"
+
+static bool _is_non_editor_binary() {
+	if (!OS::get_singleton()) {
+		return false;
+	}
+	const String exe = OS::get_singleton()->get_executable_path().get_file().to_lower();
+	return !exe.contains("editor");
+}
+
+LiveWallpaperCmdline::Mode LiveWallpaperCmdline::mode = LiveWallpaperCmdline::MODE_NONE;
+int64_t LiveWallpaperCmdline::embed_hwnd = 0;
+
+LiveWallpaperCmdline::Mode LiveWallpaperCmdline::get_mode() {
+	return mode;
+}
+
+int64_t LiveWallpaperCmdline::get_embed_hwnd() {
+	return embed_hwnd;
+}
+
+void LiveWallpaperCmdline::set_embed_hwnd(int64_t p_hwnd) {
+	embed_hwnd = p_hwnd;
+}
+
+void LiveWallpaperCmdline::reset() {
+	mode = MODE_NONE;
+	embed_hwnd = 0;
+}
+
+static String _app_key() {
+	String name = "Blazium";
+	if (ProjectSettings::get_singleton()) {
+		const String app = ProjectSettings::get_singleton()->get_setting("application/config/name", "Blazium");
+		if (!String(app).is_empty()) {
+			name = String(app);
+		}
+	}
+	return name.validate_filename();
+}
+
+String LiveWallpaperCmdline::mutex_name() {
+	return "Local\\BlaziumLiveWallpaper-" + _app_key();
+}
+
+String LiveWallpaperCmdline::quit_event_name() {
+	return "Local\\BlaziumLiveWallpaper-Quit-" + _app_key();
+}
+
+bool LiveWallpaperCmdline::try_consume(const String &p_arg, const String &p_next, bool &r_consumed_next) {
+	r_consumed_next = false;
+	(void)p_next;
+	if (p_arg == "-s" || p_arg == "--script" || p_arg == "-p" || p_arg == "--project-manager") {
+		return false;
+	}
+	if (p_arg == "--livewallpaper-preview" || p_arg == "/p" || p_arg == "/P") {
+		mode = MODE_PREVIEW;
+		return true;
+	}
+	if (p_arg == "--livewallpaper-quit") {
+		mode = MODE_QUIT;
+		return true;
+	}
+	return false;
+}
+
+void LiveWallpaperCmdline::apply_recorded(DisplayServer::WindowMode &r_window_mode, uint32_t &r_window_flags, Vector2i &r_window_position, Size2i &r_window_size, int64_t &r_embed_parent_hwnd, bool &r_use_position) {
+	r_use_position = false;
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps == nullptr || !bool(ps->get_setting("blazium/livewallpaper/enabled", false))) {
+		return;
+	}
+
+	Mode applied = mode;
+	if (applied == MODE_NONE) {
+		if (LiveWallpaperWorkerW::has_test_override() || _is_non_editor_binary()) {
+			applied = MODE_RUN;
+			mode = MODE_RUN;
+		}
+	}
+	if (applied == MODE_NONE) {
+		return;
+	}
+	if (applied == MODE_QUIT) {
+		r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+		r_window_flags &= ~DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+		r_embed_parent_hwnd = 0;
+		embed_hwnd = 0;
+		return;
+	}
+	if (applied == MODE_PREVIEW) {
+		r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+		r_window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+		r_embed_parent_hwnd = 0;
+		embed_hwnd = 0;
+		r_window_size = Size2i(640, 360);
+		return;
+	}
+
+	embed_hwnd = LiveWallpaperWorkerW::find_workerw();
+	r_embed_parent_hwnd = 0;
+	r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	r_window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+	r_window_flags |= DisplayServer::WINDOW_FLAG_NO_FOCUS_BIT;
+	r_window_position = Vector2i(-32000, -32000);
+
+	r_window_size = Size2i(256, 256);
+	r_use_position = true;
+}

--- a/modules/livewallpaper/livewallpaper_cmdline.h
+++ b/modules/livewallpaper/livewallpaper_cmdline.h
@@ -1,0 +1,59 @@
+/**************************************************************************/
+/*  livewallpaper_cmdline.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/vector2i.h"
+#include "core/string/ustring.h"
+#include "servers/display_server.h"
+
+class LiveWallpaperCmdline {
+public:
+	enum Mode {
+		MODE_NONE,
+		MODE_RUN,
+		MODE_PREVIEW,
+		MODE_QUIT,
+	};
+
+	static Mode get_mode();
+	static int64_t get_embed_hwnd();
+	static void set_embed_hwnd(int64_t p_hwnd);
+	static void reset();
+
+	static bool try_consume(const String &p_arg, const String &p_next, bool &r_consumed_next);
+	static void apply_recorded(DisplayServer::WindowMode &r_window_mode, uint32_t &r_window_flags, Vector2i &r_window_position, Size2i &r_window_size, int64_t &r_embed_parent_hwnd, bool &r_use_position);
+
+	static String mutex_name();
+	static String quit_event_name();
+
+private:
+	static Mode mode;
+	static int64_t embed_hwnd;
+};

--- a/modules/livewallpaper/livewallpaper_workerw.cpp
+++ b/modules/livewallpaper/livewallpaper_workerw.cpp
@@ -1,0 +1,305 @@
+/**************************************************************************/
+/*  livewallpaper_workerw.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "livewallpaper_workerw.h"
+
+#ifdef WINDOWS_ENABLED
+#include <windows.h>
+#endif
+
+bool LiveWallpaperWorkerW::test_override = false;
+int64_t LiveWallpaperWorkerW::test_hwnd = 0;
+bool LiveWallpaperWorkerW::test_virtual_override = false;
+Rect2i LiveWallpaperWorkerW::test_virtual;
+bool LiveWallpaperWorkerW::test_primary_override = false;
+Rect2i LiveWallpaperWorkerW::test_primary;
+
+#ifdef WINDOWS_ENABLED
+static void _compute_attach_rect(HWND p_workerw, bool p_cover_all, int &r_x, int &r_y, int &r_w, int &r_h) {
+	RECT worker_rc;
+	GetClientRect(p_workerw, &worker_rc);
+	r_x = 0;
+	r_y = 0;
+	r_w = worker_rc.right - worker_rc.left;
+	r_h = worker_rc.bottom - worker_rc.top;
+	if (!p_cover_all) {
+		const Rect2i primary = LiveWallpaperWorkerW::primary_screen_rect();
+		RECT worker_screen;
+		GetWindowRect(p_workerw, &worker_screen);
+		r_x = primary.position.x - worker_screen.left;
+		r_y = primary.position.y - worker_screen.top;
+		r_w = primary.size.x;
+		r_h = primary.size.y;
+	}
+	r_w = MAX(r_w, 1);
+	r_h = MAX(r_h, 1);
+}
+
+static BOOL CALLBACK _enum_workerw(HWND p_hwnd, LPARAM p_lparam) {
+	HWND defview = FindWindowExW(p_hwnd, nullptr, L"SHELLDLL_DefView", nullptr);
+	if (defview != nullptr) {
+		HWND *out = reinterpret_cast<HWND *>(p_lparam);
+		HWND sibling = FindWindowExW(nullptr, p_hwnd, L"WorkerW", nullptr);
+		if (sibling != nullptr) {
+			*out = sibling;
+		}
+	}
+	return TRUE;
+}
+
+static HWND _find_progman_wallpaper_workerw(HWND p_progman) {
+	HWND cur = nullptr;
+	HWND found = nullptr;
+	while ((cur = FindWindowExW(p_progman, cur, L"WorkerW", nullptr)) != nullptr) {
+		if (FindWindowExW(cur, nullptr, L"SHELLDLL_DefView", nullptr) == nullptr) {
+			found = cur;
+		}
+	}
+	return found;
+}
+
+static HWND _spawn_and_find_workerw() {
+	HWND progman = FindWindowW(L"Progman", nullptr);
+	if (progman == nullptr) {
+		return nullptr;
+	}
+	DWORD_PTR result = 0;
+	SendMessageTimeoutW(progman, 0x052C, 0, 0, SMTO_NORMAL, 1000, &result);
+	SendMessageTimeoutW(progman, 0x052C, 0xD, 0x1, SMTO_NORMAL, 1000, &result);
+
+	HWND workerw = nullptr;
+	EnumWindows(_enum_workerw, reinterpret_cast<LPARAM>(&workerw));
+	if (workerw != nullptr) {
+		return workerw;
+	}
+	return _find_progman_wallpaper_workerw(progman);
+}
+#endif
+
+int64_t LiveWallpaperWorkerW::find_workerw() {
+	if (test_override) {
+		return test_hwnd;
+	}
+#ifdef WINDOWS_ENABLED
+	HWND workerw = _spawn_and_find_workerw();
+	return (int64_t)(intptr_t)workerw;
+#else
+	return 0;
+#endif
+}
+
+bool LiveWallpaperWorkerW::attach_window(int64_t p_hwnd, int64_t p_workerw, bool p_cover_all) {
+#ifdef WINDOWS_ENABLED
+	HWND hwnd = reinterpret_cast<HWND>((intptr_t)p_hwnd);
+	HWND workerw = reinterpret_cast<HWND>((intptr_t)p_workerw);
+	if (hwnd == nullptr || workerw == nullptr || !IsWindow(hwnd) || !IsWindow(workerw)) {
+		return false;
+	}
+
+	SetParent(hwnd, workerw);
+
+	LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+	style &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+	style |= WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+	SetWindowLongPtrW(hwnd, GWL_STYLE, style);
+
+	LONG_PTR ex = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+	ex &= ~(WS_EX_APPWINDOW | WS_EX_TOPMOST | WS_EX_WINDOWEDGE);
+	ex |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_NOINHERITLAYOUT;
+	SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex);
+
+	int x = 0;
+	int y = 0;
+	int w = 1;
+	int h = 1;
+	_compute_attach_rect(workerw, p_cover_all, x, y, w, h);
+
+	SetWindowPos(hwnd, HWND_BOTTOM, 0, 0, 1, 1, SWP_NOACTIVATE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+	(void)x;
+	(void)y;
+	(void)w;
+	(void)h;
+	return GetParent(hwnd) == workerw;
+#else
+	(void)p_hwnd;
+	(void)p_workerw;
+	(void)p_cover_all;
+	return false;
+#endif
+}
+
+bool LiveWallpaperWorkerW::is_child_of(int64_t p_hwnd, int64_t p_workerw) {
+#ifdef WINDOWS_ENABLED
+	HWND hwnd = reinterpret_cast<HWND>((intptr_t)p_hwnd);
+	HWND workerw = reinterpret_cast<HWND>((intptr_t)p_workerw);
+	if (hwnd == nullptr || workerw == nullptr) {
+		return false;
+	}
+	if (GetParent(hwnd) != workerw) {
+		return false;
+	}
+	const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+	return (style & WS_CHILD) != 0 && (style & WS_POPUP) == 0;
+#else
+	(void)p_hwnd;
+	(void)p_workerw;
+	return false;
+#endif
+}
+
+Rect2i LiveWallpaperWorkerW::attach_rect(int64_t p_workerw, bool p_cover_all) {
+#ifdef WINDOWS_ENABLED
+	HWND workerw = reinterpret_cast<HWND>((intptr_t)p_workerw);
+	if (workerw == nullptr || !IsWindow(workerw)) {
+		return p_cover_all ? virtual_screen_rect() : primary_screen_rect();
+	}
+	int x = 0;
+	int y = 0;
+	int w = 1;
+	int h = 1;
+	_compute_attach_rect(workerw, p_cover_all, x, y, w, h);
+	return Rect2i(x, y, w, h);
+#else
+	return p_cover_all ? virtual_screen_rect() : primary_screen_rect();
+#endif
+}
+
+bool LiveWallpaperWorkerW::is_fully_attached(int64_t p_hwnd, int64_t p_workerw, bool p_cover_all) {
+#ifdef WINDOWS_ENABLED
+	if (!is_child_of(p_hwnd, p_workerw)) {
+		return false;
+	}
+	HWND hwnd = reinterpret_cast<HWND>((intptr_t)p_hwnd);
+	(void)p_cover_all;
+	RECT have;
+	GetClientRect(hwnd, &have);
+	const int have_w = have.right - have.left;
+	const int have_h = have.bottom - have.top;
+	return have_w <= 2 && have_h <= 2;
+#else
+	(void)p_hwnd;
+	(void)p_workerw;
+	(void)p_cover_all;
+	return false;
+#endif
+}
+
+bool LiveWallpaperWorkerW::present_bgra(int64_t p_workerw, bool p_cover_all, int p_src_width, int p_src_height, const uint8_t *p_bgra) {
+#ifdef WINDOWS_ENABLED
+	HWND workerw = reinterpret_cast<HWND>((intptr_t)p_workerw);
+	if (workerw == nullptr || !IsWindow(workerw) || p_bgra == nullptr || p_src_width < 2 || p_src_height < 2) {
+		return false;
+	}
+	int x = 0;
+	int y = 0;
+	int w = 1;
+	int h = 1;
+	_compute_attach_rect(workerw, p_cover_all, x, y, w, h);
+	BITMAPINFO bmi = {};
+	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmi.bmiHeader.biWidth = p_src_width;
+	bmi.bmiHeader.biHeight = -p_src_height;
+	bmi.bmiHeader.biPlanes = 1;
+	bmi.bmiHeader.biBitCount = 32;
+	bmi.bmiHeader.biCompression = BI_RGB;
+	HDC hdc = GetDC(workerw);
+	if (hdc == nullptr) {
+		return false;
+	}
+	const int drawn = StretchDIBits(hdc, x, y, w, h, 0, 0, p_src_width, p_src_height, p_bgra, &bmi, DIB_RGB_COLORS, SRCCOPY);
+	ReleaseDC(workerw, hdc);
+	return drawn != 0;
+#else
+	(void)p_workerw;
+	(void)p_cover_all;
+	(void)p_src_width;
+	(void)p_src_height;
+	(void)p_bgra;
+	return false;
+#endif
+}
+
+Rect2i LiveWallpaperWorkerW::virtual_screen_rect() {
+	if (test_virtual_override) {
+		return test_virtual;
+	}
+#ifdef WINDOWS_ENABLED
+	const int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+	const int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+	const int w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+	const int h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+	if (w <= 0 || h <= 0) {
+		return Rect2i(0, 0, 1920, 1080);
+	}
+	return Rect2i(x, y, w, h);
+#else
+	return Rect2i(0, 0, 1920, 1080);
+#endif
+}
+
+Rect2i LiveWallpaperWorkerW::primary_screen_rect() {
+	if (test_primary_override) {
+		return test_primary;
+	}
+#ifdef WINDOWS_ENABLED
+	const int w = GetSystemMetrics(SM_CXSCREEN);
+	const int h = GetSystemMetrics(SM_CYSCREEN);
+	return Rect2i(0, 0, MAX(w, 1), MAX(h, 1));
+#else
+	return Rect2i(0, 0, 1920, 1080);
+#endif
+}
+
+bool LiveWallpaperWorkerW::has_test_override() {
+	return test_override;
+}
+
+void LiveWallpaperWorkerW::reset_for_tests() {
+	test_override = false;
+	test_hwnd = 0;
+	test_virtual_override = false;
+	test_virtual = Rect2i();
+	test_primary_override = false;
+	test_primary = Rect2i();
+}
+
+void LiveWallpaperWorkerW::set_workerw_for_tests(int64_t p_hwnd) {
+	test_override = true;
+	test_hwnd = p_hwnd;
+}
+
+void LiveWallpaperWorkerW::set_virtual_rect_for_tests(const Rect2i &p_rect) {
+	test_virtual_override = true;
+	test_virtual = p_rect;
+}
+
+void LiveWallpaperWorkerW::set_primary_rect_for_tests(const Rect2i &p_rect) {
+	test_primary_override = true;
+	test_primary = p_rect;
+}

--- a/modules/livewallpaper/livewallpaper_workerw.h
+++ b/modules/livewallpaper/livewallpaper_workerw.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  livewallpaper_workerw.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/rect2i.h"
+
+class LiveWallpaperWorkerW {
+public:
+	static int64_t find_workerw();
+	static bool attach_window(int64_t p_hwnd, int64_t p_workerw, bool p_cover_all);
+	static bool is_child_of(int64_t p_hwnd, int64_t p_workerw);
+	static bool is_fully_attached(int64_t p_hwnd, int64_t p_workerw, bool p_cover_all);
+	static Rect2i attach_rect(int64_t p_workerw, bool p_cover_all);
+	static bool present_bgra(int64_t p_workerw, bool p_cover_all, int p_src_width, int p_src_height, const uint8_t *p_bgra);
+	static Rect2i virtual_screen_rect();
+	static Rect2i primary_screen_rect();
+
+	static void reset_for_tests();
+	static bool has_test_override();
+	static void set_workerw_for_tests(int64_t p_hwnd);
+	static void set_virtual_rect_for_tests(const Rect2i &p_rect);
+	static void set_primary_rect_for_tests(const Rect2i &p_rect);
+
+private:
+	static bool test_override;
+	static int64_t test_hwnd;
+	static bool test_virtual_override;
+	static Rect2i test_virtual;
+	static bool test_primary_override;
+	static Rect2i test_primary;
+};

--- a/modules/livewallpaper/register_types.cpp
+++ b/modules/livewallpaper/register_types.cpp
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "core/config/engine.h"
+#include "core/object/message_queue.h"
+#include "livewallpaper.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/export/windows_livewallpaper_export_platform.h"
+#include "editor/livewallpaper_editor_plugin.h"
+#include "editor/plugins/editor_plugin.h"
+#endif
+
+static LiveWallpaper *livewallpaper_singleton = nullptr;
+
+static void _livewallpaper_boot() {
+	if (LiveWallpaper::get_singleton()) {
+		LiveWallpaper::get_singleton()->setup_runtime();
+	}
+}
+
+void initialize_livewallpaper_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		LiveWallpaper::register_project_settings();
+		return;
+	}
+
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformWindowsLiveWallpaper);
+		GDREGISTER_CLASS(LiveWallpaperEditorPlugin);
+		EditorPlugins::add_by_type<LiveWallpaperEditorPlugin>();
+		return;
+	}
+#endif
+
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	GDREGISTER_CLASS(LiveWallpaper);
+	livewallpaper_singleton = memnew(LiveWallpaper);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("LiveWallpaper", LiveWallpaper::get_singleton()));
+	if (MessageQueue::get_singleton()) {
+		callable_mp_static(&_livewallpaper_boot).call_deferred();
+	}
+}
+
+void uninitialize_livewallpaper_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+#endif
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	Engine::get_singleton()->remove_singleton("LiveWallpaper");
+	if (livewallpaper_singleton) {
+		memdelete(livewallpaper_singleton);
+		livewallpaper_singleton = nullptr;
+	}
+}

--- a/modules/livewallpaper/register_types.h
+++ b/modules/livewallpaper/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_livewallpaper_module(ModuleInitializationLevel p_level);
+void uninitialize_livewallpaper_module(ModuleInitializationLevel p_level);

--- a/modules/livewallpaper/tests/test_livewallpaper.cpp
+++ b/modules/livewallpaper/tests/test_livewallpaper.cpp
@@ -1,0 +1,31 @@
+/**************************************************************************/
+/*  test_livewallpaper.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_livewallpaper_cmdline.h"
+#include "test_livewallpaper_workerw.h"

--- a/modules/livewallpaper/tests/test_livewallpaper_cmdline.h
+++ b/modules/livewallpaper/tests/test_livewallpaper_cmdline.h
@@ -1,0 +1,144 @@
+/**************************************************************************/
+/*  test_livewallpaper_cmdline.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/config/project_settings.h"
+#include "modules/livewallpaper/livewallpaper_cmdline.h"
+#include "modules/livewallpaper/livewallpaper_workerw.h"
+#include "tests/test_macros.h"
+
+TEST_CASE("[Modules][LiveWallpaper] consume preview and quit") {
+	LiveWallpaperCmdline::reset();
+	bool consumed_next = false;
+	CHECK(LiveWallpaperCmdline::try_consume("--livewallpaper-preview", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_PREVIEW);
+
+	LiveWallpaperCmdline::reset();
+	CHECK(LiveWallpaperCmdline::try_consume("/p", "", consumed_next));
+	CHECK(LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_PREVIEW);
+
+	LiveWallpaperCmdline::reset();
+	CHECK(LiveWallpaperCmdline::try_consume("--livewallpaper-quit", "", consumed_next));
+	CHECK(LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_QUIT);
+}
+
+TEST_CASE("[Modules][LiveWallpaper] ignore Godot -s --script and -p") {
+	LiveWallpaperCmdline::reset();
+	bool consumed_next = false;
+	CHECK_FALSE(LiveWallpaperCmdline::try_consume("-s", "res://x.gd", consumed_next));
+	CHECK_FALSE(LiveWallpaperCmdline::try_consume("--script", "res://x.gd", consumed_next));
+	CHECK_FALSE(LiveWallpaperCmdline::try_consume("-p", "", consumed_next));
+	CHECK_FALSE(LiveWallpaperCmdline::try_consume("--project-manager", "", consumed_next));
+	CHECK(LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_NONE);
+}
+
+TEST_CASE("[Modules][LiveWallpaper] apply_recorded modes and enabled gate") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/livewallpaper/enabled", false));
+	const bool prev_cover = bool(ps->get_setting("blazium/livewallpaper/cover_all_screens", true));
+
+	LiveWallpaperWorkerW::reset_for_tests();
+	LiveWallpaperWorkerW::set_workerw_for_tests(12345);
+	LiveWallpaperWorkerW::set_virtual_rect_for_tests(Rect2i(10, 20, 800, 600));
+	LiveWallpaperWorkerW::set_primary_rect_for_tests(Rect2i(0, 0, 640, 480));
+
+	ps->set_setting("blazium/livewallpaper/enabled", false);
+	LiveWallpaperCmdline::reset();
+	bool consumed_next = false;
+	CHECK(LiveWallpaperCmdline::try_consume("--livewallpaper-preview", "", consumed_next));
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = 0;
+	Vector2i pos(1, 1);
+	Size2i size(100, 100);
+	int64_t embed = 99;
+	bool use_pos = true;
+	LiveWallpaperCmdline::apply_recorded(window_mode, flags, pos, size, embed, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK(embed == 99);
+	CHECK_FALSE(use_pos);
+
+	ps->set_setting("blazium/livewallpaper/enabled", true);
+	LiveWallpaperCmdline::reset();
+	CHECK(LiveWallpaperCmdline::try_consume("--livewallpaper-preview", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = 0;
+	pos = Vector2i(1, 1);
+	size = Size2i(100, 100);
+	embed = 99;
+	use_pos = true;
+	LiveWallpaperCmdline::apply_recorded(window_mode, flags, pos, size, embed, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK(embed == 0);
+	CHECK(LiveWallpaperCmdline::get_embed_hwnd() == 0);
+	CHECK(size == Size2i(640, 360));
+	CHECK_FALSE(use_pos);
+
+	ps->set_setting("blazium/livewallpaper/cover_all_screens", true);
+	LiveWallpaperCmdline::reset();
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = 0;
+	pos = Vector2i();
+	size = Size2i();
+	embed = 0;
+	use_pos = false;
+	LiveWallpaperCmdline::apply_recorded(window_mode, flags, pos, size, embed, use_pos);
+	CHECK(LiveWallpaperCmdline::get_mode() == LiveWallpaperCmdline::MODE_RUN);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_NO_FOCUS_BIT) != 0);
+	CHECK(embed == 0);
+	CHECK(LiveWallpaperCmdline::get_embed_hwnd() == 12345);
+	CHECK(size == Size2i(256, 256));
+	CHECK(use_pos);
+
+	ps->set_setting("blazium/livewallpaper/cover_all_screens", false);
+	LiveWallpaperCmdline::reset();
+	window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	flags = 0;
+	pos = Vector2i();
+	size = Size2i();
+	embed = 7;
+	use_pos = false;
+	LiveWallpaperCmdline::apply_recorded(window_mode, flags, pos, size, embed, use_pos);
+	CHECK(embed == 0);
+	CHECK(LiveWallpaperCmdline::get_embed_hwnd() == 12345);
+	CHECK(size == Size2i(256, 256));
+
+	CHECK(LiveWallpaperCmdline::mutex_name().contains("BlaziumLiveWallpaper-"));
+	CHECK(LiveWallpaperCmdline::quit_event_name().contains("BlaziumLiveWallpaper-Quit-"));
+
+	LiveWallpaperCmdline::reset();
+	LiveWallpaperWorkerW::reset_for_tests();
+	ps->set_setting("blazium/livewallpaper/enabled", prev_enabled);
+	ps->set_setting("blazium/livewallpaper/cover_all_screens", prev_cover);
+}

--- a/modules/livewallpaper/tests/test_livewallpaper_workerw.h
+++ b/modules/livewallpaper/tests/test_livewallpaper_workerw.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  test_livewallpaper_workerw.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/livewallpaper/livewallpaper_workerw.h"
+#include "tests/test_macros.h"
+
+TEST_CASE("[Modules][LiveWallpaper] workerw helpers and test inject") {
+	LiveWallpaperWorkerW::reset_for_tests();
+	LiveWallpaperWorkerW::find_workerw();
+
+	LiveWallpaperWorkerW::set_workerw_for_tests(4242);
+	CHECK(LiveWallpaperWorkerW::find_workerw() == 4242);
+
+	LiveWallpaperWorkerW::set_virtual_rect_for_tests(Rect2i(5, 6, 700, 500));
+	CHECK(LiveWallpaperWorkerW::virtual_screen_rect() == Rect2i(5, 6, 700, 500));
+
+	LiveWallpaperWorkerW::set_primary_rect_for_tests(Rect2i(0, 0, 320, 240));
+	CHECK(LiveWallpaperWorkerW::primary_screen_rect() == Rect2i(0, 0, 320, 240));
+
+	const Rect2i live = LiveWallpaperWorkerW::virtual_screen_rect();
+	CHECK(live.size.x > 0);
+	CHECK(live.size.y > 0);
+
+	LiveWallpaperWorkerW::reset_for_tests();
+	LiveWallpaperWorkerW::find_workerw();
+
+	CHECK_FALSE(LiveWallpaperWorkerW::attach_window(0, 1, true));
+	CHECK_FALSE(LiveWallpaperWorkerW::attach_window(1, 0, true));
+	CHECK_FALSE(LiveWallpaperWorkerW::is_child_of(0, 1));
+	CHECK_FALSE(LiveWallpaperWorkerW::is_fully_attached(0, 1, true));
+	CHECK_FALSE(LiveWallpaperWorkerW::is_fully_attached(1, 0, false));
+	CHECK_FALSE(LiveWallpaperWorkerW::present_bgra(0, true, 4, 4, nullptr));
+
+	LiveWallpaperWorkerW::set_virtual_rect_for_tests(Rect2i(-100, -50, 2560, 1440));
+	LiveWallpaperWorkerW::set_primary_rect_for_tests(Rect2i(0, 0, 1920, 1080));
+	CHECK(LiveWallpaperWorkerW::attach_rect(0, true) == Rect2i(-100, -50, 2560, 1440));
+	CHECK(LiveWallpaperWorkerW::attach_rect(0, false) == Rect2i(0, 0, 1920, 1080));
+
+	LiveWallpaperWorkerW::reset_for_tests();
+}

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -218,7 +218,7 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 			}
 		}
 		tmp_app_dir->make_dir_recursive(tmp_dir_path);
-		path = tmp_dir_path.path_join(p_path.get_file().get_basename() + ".exe");
+		path = tmp_dir_path.path_join(p_path.get_file().get_basename() + "." + get_exported_executable_extension());
 	}
 
 	int export_angle = p_preset->get("application/export_angle");

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -86,6 +86,7 @@ public:
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
 
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual String get_exported_executable_extension() const { return "exe"; }
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 
 	virtual Ref<Texture2D> get_run_icon() const override;


### PR DESCRIPTION
## Summary
- Add the `livewallpaper` module that embeds a Blazium window in the Windows desktop WorkerW.
- Windows editor and `livewallpaper_template` builds only. Wires `--livewallpaper-preview` / `--livewallpaper-quit` and the LiveWallpaper singleton.

## Test plan
- [ ] Build `platform=windows target=editor tests=yes`
- [ ] Run `--headless --test --test-case=*[LiveWallpaper]*`
- [ ] Confirm Linux/macOS/Android editors skip the module