### PR TITLE
Add Windows screensaver module

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -134,6 +134,9 @@
 #ifdef MODULE_LIVEWALLPAPER_ENABLED
 #include "modules/livewallpaper/livewallpaper_cmdline.h"
 #endif
+#ifdef MODULE_SCREENSAVER_ENABLED
+#include "modules/screensaver/screensaver_cmdline.h"
+#endif
 
 #if defined(MODULE_MONO_ENABLED) && defined(TOOLS_ENABLED)
 #include "modules/mono/editor/bindings_generator.h"
@@ -1132,6 +1135,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef MODULE_LIVEWALLPAPER_ENABLED
 		bool livewallpaper_consumed_next = false;
 #endif
+#ifdef MODULE_SCREENSAVER_ENABLED
+		bool screensaver_consumed_next = false;
+#endif
 
 		const String &arg = I->get();
 
@@ -1402,6 +1408,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (N) {
 				init_screen = N->get().to_int();
 				init_use_custom_screen = true;
+#ifdef MODULE_SCREENSAVER_ENABLED
+				ScreensaverCmdline::set_target_screen(init_screen);
+#endif
 
 				N = N->next();
 			} else {
@@ -1974,6 +1983,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif
 				LiveWallpaperCmdline::try_consume(arg, N ? N->get() : String(), livewallpaper_consumed_next)) {
 			if (livewallpaper_consumed_next && N) {
+				N = N->next();
+			}
+#endif
+#ifdef MODULE_SCREENSAVER_ENABLED
+		} else if (
+#ifdef TOOLS_ENABLED
+				!editor && !project_manager &&
+#endif
+				ScreensaverCmdline::try_consume(arg, N ? N->get() : String(), screensaver_consumed_next)) {
+			if (screensaver_consumed_next && N) {
 				N = N->next();
 			}
 #endif
@@ -3210,6 +3229,16 @@ Error Main::setup2(bool p_show_boot_logo) {
 		LiveWallpaperCmdline::apply_recorded(window_mode, window_flags, position, window_size, init_embed_parent_window_id, livewallpaper_use_position);
 		if (livewallpaper_use_position) {
 			window_position = &position;
+		}
+#endif
+#ifdef MODULE_SCREENSAVER_ENABLED
+		bool screensaver_use_position = false;
+		ScreensaverCmdline::apply_recorded(window_mode, window_flags, init_embed_parent_window_id, position, window_size, init_screen, screensaver_use_position);
+		if (screensaver_use_position) {
+			window_position = &position;
+		} else if (ScreensaverCmdline::should_clear_create_position()) {
+			// Project absolute (0,0) / exported initial_position_type=0 would ignore --screen.
+			window_position = nullptr;
 		}
 #endif
 

--- a/modules/screensaver/SCsub
+++ b/modules/screensaver/SCsub
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_screensaver = env_modules.Clone()
+
+env_screensaver.add_source_files(env.modules_sources, "register_types.cpp")
+env_screensaver.add_source_files(env.modules_sources, "screensaver_cmdline.cpp")
+env_screensaver.add_source_files(env.modules_sources, "screensaver_password.cpp")
+env_screensaver.add_source_files(env.modules_sources, "screensaver.cpp")
+
+if env.editor_build:
+    env_screensaver.add_source_files(env.modules_sources, "editor/*.cpp")
+    env_screensaver.add_source_files(env.modules_sources, "editor/export/*.cpp")
+
+if env["tests"]:
+    env_screensaver.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_screensaver.add_source_files(env.modules_sources, "tests/*.cpp")
+    if env["disable_exceptions"]:
+        env_screensaver.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/screensaver/config.py
+++ b/modules/screensaver/config.py
@@ -1,0 +1,35 @@
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable(
+            "screensaver_template",
+            "Build screensaver-flavored export templates (.screensaver suffix)",
+            False,
+        ),
+    ]
+
+
+def can_build(env, platform):
+    if platform != "windows":
+        return False
+    if env.editor_build:
+        return True
+    return bool(env.get("screensaver_template", False))
+
+
+def configure(env):
+    if not env.editor_build:
+        env.add_module_version_string("screensaver")
+
+
+def get_doc_classes():
+    return [
+        "Screensaver",
+        "ScreensaverEditorPlugin",
+        "EditorExportPlatformWindowsScreensaver",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/screensaver/doc_classes/EditorExportPlatformWindowsScreensaver.xml
+++ b/modules/screensaver/doc_classes/EditorExportPlatformWindowsScreensaver.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformWindowsScreensaver" inherits="EditorExportPlatformWindows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Exports a Windows [code].scr[/code] using screensaver-flavored templates.
+	</brief_description>
+	<description>
+		Looks up [code]windows_{debug|release}_{arch}.screensaver.exe[/code] only. There is no fallback to the Desktop [code]windows_*.exe[/code] template. Packed project settings force [code]blazium/screensaver/enabled=true[/code]. Build those templates with [code]screensaver_template=yes[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="application/company_name" type="String" setter="" getter="">
+		</member>
+		<member name="application/console_wrapper_icon" type="String" setter="" getter="">
+		</member>
+		<member name="application/copyright" type="String" setter="" getter="">
+		</member>
+		<member name="application/d3d12_agility_sdk_multiarch" type="bool" setter="" getter="">
+		</member>
+		<member name="application/export_angle" type="int" setter="" getter="">
+		</member>
+		<member name="application/export_d3d12" type="int" setter="" getter="">
+		</member>
+		<member name="application/file_description" type="String" setter="" getter="">
+		</member>
+		<member name="application/file_version" type="String" setter="" getter="">
+		</member>
+		<member name="application/icon" type="String" setter="" getter="">
+		</member>
+		<member name="application/icon_interpolation" type="int" setter="" getter="">
+		</member>
+		<member name="application/modify_resources" type="bool" setter="" getter="">
+		</member>
+		<member name="application/product_name" type="String" setter="" getter="">
+		</member>
+		<member name="application/product_version" type="String" setter="" getter="">
+		</member>
+		<member name="application/trademarks" type="String" setter="" getter="">
+		</member>
+		<member name="binary_format/architecture" type="String" setter="" getter="">
+		</member>
+		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/custom_options" type="PackedStringArray" setter="" getter="">
+		</member>
+		<member name="codesign/description" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/digest_algorithm" type="int" setter="" getter="">
+		</member>
+		<member name="codesign/enable" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/identity" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/identity_type" type="int" setter="" getter="">
+		</member>
+		<member name="codesign/password" type="String" setter="" getter="">
+		</member>
+		<member name="codesign/timestamp" type="bool" setter="" getter="">
+		</member>
+		<member name="codesign/timestamp_server_url" type="String" setter="" getter="">
+		</member>
+		<member name="custom_template/debug" type="String" setter="" getter="">
+		</member>
+		<member name="custom_template/release" type="String" setter="" getter="">
+		</member>
+		<member name="debug/export_console_wrapper" type="int" setter="" getter="">
+		</member>
+		<member name="screensaver/change_password_scene" type="String" setter="" getter="">
+		</member>
+		<member name="screensaver/configure_scene" type="String" setter="" getter="">
+		</member>
+		<member name="screensaver/cover_all_screens" type="bool" setter="" getter="">
+			Fallback when [member screensaver/cover_mode] is empty: [code]true[/code] maps to [code]virtual[/code], [code]false[/code] to [code]single[/code].
+		</member>
+		<member name="screensaver/cover_mode" type="String" setter="" getter="">
+			[code]virtual[/code] (span every monitor, default for a Windows [code]/S[/code] host launch), [code]single[/code] (one monitor), or [code]clone[/code] (one window per monitor). [code]--screen N[/code] / [code]/s:N[/code] or a CreateProcess child launch pin [code]single[/code]. Override at run time with [code]--screensaver-cover[/code]. Packed as [code]blazium/screensaver/cover_mode[/code].
+		</member>
+		<member name="screensaver/description" type="String" setter="" getter="">
+		</member>
+		<member name="screensaver/lock_workstation_on_exit" type="bool" setter="" getter="">
+		</member>
+		<member name="screensaver/password_enabled" type="bool" setter="" getter="">
+		</member>
+		<member name="screensaver/quit_on_input" type="bool" setter="" getter="">
+		</member>
+		<member name="screensaver/quit_on_mouse_move_threshold" type="int" setter="" getter="">
+		</member>
+		<member name="screensaver/screen" type="int" setter="" getter="">
+			Default monitor index for [code]single[/code] and [code]clone[/code] when [code]--screen[/code] / [code]/s:N[/code] is not passed. [code]-1[/code] keeps the engine primary-screen default. Packed as [code]blazium/screensaver/screen[/code].
+		</member>
+		<member name="screensaver/unlock_scene" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/cleanup_script" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/enabled" type="bool" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/extra_args_scp" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/extra_args_ssh" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/host" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/port" type="String" setter="" getter="">
+		</member>
+		<member name="ssh_remote_deploy/run_script" type="String" setter="" getter="">
+		</member>
+		<member name="texture_format/etc2_astc" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/s3tc_bptc" type="bool" setter="" getter="">
+		</member>
+	</members>
+</class>

--- a/modules/screensaver/doc_classes/Screensaver.xml
+++ b/modules/screensaver/doc_classes/Screensaver.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Screensaver" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Runtime singleton for Windows screensaver modes ([code]/s[/code], [code]/p[/code], [code]/c[/code], [code]/a[/code]).
+	</brief_description>
+	<description>
+		[Screensaver] is compiled only when the screensaver module is enabled. Command-line switches apply only when [code]blazium/screensaver/enabled[/code] is [code]true[/code] in the exported project. Password hashes are stored per-user (HKCU on Windows, [code]user://screensaver_password.cfg[/code] elsewhere) and never as plaintext in the PCK.
+		Windows 11 Screen Saver Settings (desk.cpl) launches the same [code].scr[/code] with [code]/p hwnd[/code], [code]/p:hwnd[/code], or [code]/s hwnd[/code] for the dropdown preview (a [code]WS_CHILD[/code] of the pane, not a centered popup); [code]/c[/code], [code]/c:hwnd[/code], [code]/c hwnd[/code], or older [code]/cHWND[/code] (no colon or space) for Settings; and bare [code]/s[/code] with no HWND for the Preview button or idle desktop cover. Settings ([code]/c[/code]) and change-password ([code]/a[/code]) open a visible owned dialog above desk.cpl; they are never embedded in the preview pane. A missing, zero, or invalid configure HWND stays [code]/c[/code] and never falls through to fullscreen [code]/s[/code]. Only bare [code]/s[/code] covers the desktop. A [code].scr[/code] with no arguments is configure, not run. [code]application/run/main_scene[/code] is the [code]/s[/code] / [code]/p[/code] animation. Do not set it to [code]unlock_scene[/code]. [code]unlock_scene[/code] is shown only when dismissing [code]/s[/code] if a password is enabled and set. Settings ([code]/c[/code]) and change-password ([code]/a[/code]) never load unlock; a missing configure or change-password scene falls back to the builtin dialog. The desk.cpl checkbox [i]On resume, display logon screen[/i] is Windows [code]ScreenSaverIsSecure[/code], not [code]unlock_scene[/code].
+		[code]/s[/code] run coverage is selected by [code]blazium/screensaver/cover_mode[/code] ([code]single[/code], [code]virtual[/code], or [code]clone[/code]), or by [code]--screensaver-cover[/code]. A Windows host launch ([code]explorer.exe[/code] / [code]winlogon.exe[/code] [code]/S[/code], including the [code].scr[/code] open verb) spans every monitor even when the packed cover mode is [code]single[/code]. desk.cpl / [code]rundll32.exe[/code] is not an idle host launch. [code]cover_all_screens=true[/code] falls back to [code]virtual[/code] for CreateProcess child launches. [code]--screen N[/code], [code]/s:N[/code], [code]/s N[/code], or [code]blazium/screensaver/screen[/code] pin a borderless windowed cover to that monitor and override [code]virtual[/code]. Indexes are 0-based: [code]0[/code] is the primary monitor, then remaining displays left-to-right. A Windows-style value equal to the monitor count maps to the last display. Launching a [code].scr[/code] through Explorer or PowerShell uses the Windows open verb and only passes [code]/S[/code], so [code]--screen[/code] and [code]--screensaver-cover[/code] never reach the process. Use [code]CreateProcess[/code] (not ShellExecute), or set [code]BLAZIUM_SCREENSAVER_SCREEN[/code] and [code]BLAZIUM_SCREENSAVER_COVER[/code]. Placement uses a native popup [code]SetWindowPos[/code] every frame (not Godot [code]window_set_mode[/code] / [code]window_set_flag[/code]) so DisplayServer cannot snap the HWND back to the primary. The cover fills the chosen display. If a virtual span is clipped to one monitor, the other displays are covered with clone windows. [code]clone[/code] still copies the other monitors. Run mode never uses exclusive fullscreen. Chrome is forced borderless again each frame so Godot cannot restore a titled Main Menu window.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="clear_password">
+			<return type="int" enum="Error" />
+			<param index="0" name="current_plain" type="String" />
+			<description>
+				Clears the stored password hash after verifying [param current_plain].
+			</description>
+		</method>
+		<method name="get_mode" qualifiers="const">
+			<return type="int" enum="Screensaver.Mode" />
+			<description>
+				Returns the active screensaver mode, or [constant MODE_DISABLED] when the project setting is off.
+			</description>
+		</method>
+		<method name="has_password" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a password hash is stored for this application.
+			</description>
+		</method>
+		<method name="is_password_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns the per-user stored override if [method set_password_enabled] has been called, otherwise [code]blazium/screensaver/password_enabled[/code].
+			</description>
+		</method>
+		<method name="is_preview" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when launched with [code]/p[/code] (Control Panel preview). Preview never prompts for a password.
+			</description>
+		</method>
+		<method name="request_exit">
+			<return type="void" />
+			<description>
+				Starts dismiss. In run mode with a password, opens the unlock UI instead of quitting.
+			</description>
+		</method>
+		<method name="set_password">
+			<return type="int" enum="Error" />
+			<param index="0" name="old_plain" type="String" />
+			<param index="1" name="new_plain" type="String" />
+			<description>
+				Sets or changes the password. An empty [param new_plain] clears the secret. The hash is never written to [code]project.blazium[/code].
+			</description>
+		</method>
+		<method name="set_password_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Persists whether unlock is required on dismiss. Stored per-user (HKCU on Windows, [code]user://screensaver_password.cfg[/code] elsewhere) so Control Panel [code]/c[/code] survives an exported [code].scr[/code].
+			</description>
+		</method>
+		<method name="verify_password" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="plain" type="String" />
+			<description>
+				Returns [code]true[/code] if [param plain] matches the stored salt+SHA-256 hash.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="password_changed">
+			<description>
+				Emitted after [method set_password] succeeds.
+			</description>
+		</signal>
+		<signal name="unlock_failed">
+			<description>
+				Emitted when unlock verification fails.
+			</description>
+		</signal>
+		<signal name="unlock_succeeded">
+			<description>
+				Emitted when unlock verification succeeds, just before quit.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="MODE_DISABLED" value="0" enum="Mode">
+			Screensaver project setting is off, or no Control Panel switch was applied.
+		</constant>
+		<constant name="MODE_RUN" value="1" enum="Mode">
+			Borderless desktop cover ([code]/s[/code] or [code]/s:N[/code]). A [code].scr[/code] with no switch is configure, not run. Cover modes: [code]single[/code] (one monitor), [code]virtual[/code] (one window spanning the virtual desktop), [code]clone[/code] (one fullscreen window per monitor).
+		</constant>
+		<constant name="MODE_PREVIEW" value="2" enum="Mode">
+			Embedded preview ([code]/p[/code], [code]/p:hwnd[/code], [code]/s hwnd[/code], or a bare HWND). Parent as a [code]WS_CHILD[/code] at 0,0 in the desk.cpl preview pane. Never a centered standalone window.
+		</constant>
+		<constant name="MODE_CONFIGURE" value="3" enum="Mode">
+			Configure dialog ([code]/c[/code], [code]/c:hwnd[/code], [code]/c hwnd[/code], [code]/cHWND[/code], or a [code].scr[/code] with no arguments). A failed HWND stays configure. Shown as a visible owned dialog above desk.cpl, never embedded. Never shows [code]unlock_scene[/code].
+		</constant>
+		<constant name="MODE_CHANGE_PASSWORD" value="4" enum="Mode">
+			Change-password dialog ([code]/a[/code]). Visible owned dialog, never embedded in the preview pane.
+		</constant>
+	</constants>
+</class>

--- a/modules/screensaver/doc_classes/ScreensaverEditorPlugin.xml
+++ b/modules/screensaver/doc_classes/ScreensaverEditorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ScreensaverEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Registers the Windows Screensaver export platform.
+	</brief_description>
+	<description>
+		Adds [EditorExportPlatformWindowsScreensaver]. Starter scenes live in the screensaver_module_tests project, not in the engine.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/screensaver/editor/export/windows_screensaver_export_platform.cpp
+++ b/modules/screensaver/editor/export/windows_screensaver_export_platform.cpp
@@ -1,0 +1,151 @@
+/**************************************************************************/
+/*  windows_screensaver_export_platform.cpp                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "windows_screensaver_export_platform.h"
+
+#include "core/io/file_access.h"
+#include "editor/editor_string_names.h"
+
+EditorExportPlatformWindowsScreensaver::EditorExportPlatformWindowsScreensaver() {
+	set_name("Windows Screensaver");
+	set_os_name("Windows");
+}
+
+String EditorExportPlatformWindowsScreensaver::get_template_file_name(const String &p_target, const String &p_arch) const {
+	return "windows_" + p_target + "_" + p_arch + ".screensaver.exe";
+}
+
+List<String> EditorExportPlatformWindowsScreensaver::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> list;
+	list.push_back("scr");
+	list.push_back("zip");
+	return list;
+}
+
+void EditorExportPlatformWindowsScreensaver::get_export_options(List<ExportOption> *r_options) const {
+	List<ExportOption> parent;
+	EditorExportPlatformWindows::get_export_options(&parent);
+	for (const ExportOption &opt : parent) {
+		if (opt.option.name == "binary_format/embed_pck") {
+			r_options->push_back(ExportOption(opt.option, true, opt.update_visibility, opt.required));
+		} else if (opt.option.name == "custom_template/debug" || opt.option.name == "custom_template/release") {
+			r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, opt.option.name, PROPERTY_HINT_GLOBAL_FILE, "*.screensaver.exe,*.exe"), opt.default_value, opt.update_visibility, opt.required));
+		} else if (opt.option.name == "debug/export_console_wrapper") {
+			r_options->push_back(ExportOption(opt.option, 0, opt.update_visibility, opt.required));
+		} else {
+			r_options->push_back(opt);
+		}
+	}
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "screensaver/configure_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), "res://configure.tscn"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "screensaver/unlock_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), "res://unlock.tscn"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "screensaver/change_password_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), "res://change_password.tscn"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screensaver/password_enabled"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screensaver/lock_workstation_on_exit"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screensaver/quit_on_input"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "screensaver/quit_on_mouse_move_threshold", PROPERTY_HINT_RANGE, "0,64,1"), 5));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screensaver/cover_all_screens"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "screensaver/cover_mode", PROPERTY_HINT_ENUM, "single,virtual,clone"), "virtual"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "screensaver/screen", PROPERTY_HINT_RANGE, "-1,16,1"), -1));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "screensaver/description"), ""));
+}
+
+String EditorExportPlatformWindowsScreensaver::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {
+	if (p_preset && (p_name == "screensaver/configure_scene" || p_name == "screensaver/unlock_scene" || p_name == "screensaver/change_password_scene")) {
+		const String path = p_preset->get(p_name);
+		if (!path.is_empty() && !FileAccess::exists(path)) {
+			return vformat(TTR("Screensaver scene does not exist: %s"), path);
+		}
+		return String();
+	}
+	return EditorExportPlatformWindows::get_export_option_warning(p_preset, p_name);
+}
+
+bool EditorExportPlatformWindowsScreensaver::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
+	if (p_option == "debug/export_console_wrapper" || p_option == "application/console_wrapper_icon") {
+		return false;
+	}
+	return EditorExportPlatformWindows::get_export_option_visibility(p_preset, p_option);
+}
+
+void EditorExportPlatformWindowsScreensaver::get_platform_features(List<String> *r_features) const {
+	EditorExportPlatformWindows::get_platform_features(r_features);
+	r_features->push_back("screensaver");
+}
+
+void EditorExportPlatformWindowsScreensaver::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+	EditorExportPlatformWindows::get_preset_features(p_preset, r_features);
+	r_features->push_back("screensaver");
+}
+
+bool EditorExportPlatformWindowsScreensaver::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	String err;
+	const bool valid = EditorExportPlatformWindows::has_valid_export_configuration(p_preset, err, r_missing_templates, p_debug);
+	if (r_missing_templates) {
+		err += TTR("Screensaver exports require windows_{debug|release}_{arch}.screensaver.exe templates (build with screensaver_template=yes). The unflavored Windows Desktop template cannot be used.") + "\n";
+	}
+	if (!err.is_empty()) {
+		r_error = err;
+	}
+	return valid;
+}
+
+HashMap<String, Variant> EditorExportPlatformWindowsScreensaver::get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const {
+	HashMap<String, Variant> settings;
+	settings["blazium/screensaver/enabled"] = true;
+	settings["blazium/screensaver/configure_scene"] = p_preset->get("screensaver/configure_scene");
+	settings["blazium/screensaver/unlock_scene"] = p_preset->get("screensaver/unlock_scene");
+	settings["blazium/screensaver/change_password_scene"] = p_preset->get("screensaver/change_password_scene");
+	settings["blazium/screensaver/password_enabled"] = p_preset->get("screensaver/password_enabled");
+	settings["blazium/screensaver/lock_workstation_on_exit"] = p_preset->get("screensaver/lock_workstation_on_exit");
+	settings["blazium/screensaver/quit_on_input"] = p_preset->get("screensaver/quit_on_input");
+	settings["blazium/screensaver/quit_on_mouse_move_threshold"] = p_preset->get("screensaver/quit_on_mouse_move_threshold");
+	settings["blazium/screensaver/cover_all_screens"] = p_preset->get("screensaver/cover_all_screens");
+	settings["blazium/screensaver/cover_mode"] = p_preset->get("screensaver/cover_mode");
+	settings["blazium/screensaver/screen"] = p_preset->get("screensaver/screen");
+
+	settings["display/window/size/mode"] = 0;
+	const String description = p_preset->get("screensaver/description");
+	if (!description.is_empty()) {
+		settings["application/config/description"] = description;
+	}
+	return settings;
+}
+
+Error EditorExportPlatformWindowsScreensaver::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	String path = p_path;
+	if (!path.get_extension().to_lower().ends_with("zip") && path.get_extension().to_lower() != "scr") {
+		path = path.get_basename() + ".scr";
+	}
+	return EditorExportPlatformWindows::export_project(p_preset, p_debug, path, p_flags);
+}
+
+#endif

--- a/modules/screensaver/editor/export/windows_screensaver_export_platform.h
+++ b/modules/screensaver/editor/export/windows_screensaver_export_platform.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  windows_screensaver_export_platform.h                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "platform/windows/export/export_plugin.h"
+
+class EditorExportPlatformWindowsScreensaver : public EditorExportPlatformWindows {
+	GDCLASS(EditorExportPlatformWindowsScreensaver, EditorExportPlatformWindows);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	EditorExportPlatformWindowsScreensaver();
+
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual String get_exported_executable_extension() const override { return "scr"; }
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
+	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
+	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+};
+
+#endif

--- a/modules/screensaver/editor/screensaver_editor_plugin.cpp
+++ b/modules/screensaver/editor/screensaver_editor_plugin.cpp
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  screensaver_editor_plugin.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "screensaver_editor_plugin.h"
+
+#include "export/windows_screensaver_export_platform.h"
+
+#include "editor/export/editor_export.h"
+
+void ScreensaverEditorPlugin::_bind_methods() {
+}
+
+void ScreensaverEditorPlugin::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (EditorExport::get_singleton()) {
+			Ref<EditorExportPlatformWindowsScreensaver> platform;
+			platform.instantiate();
+			export_platform = platform;
+			EditorExport::get_singleton()->add_export_platform(export_platform);
+		}
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (export_platform.is_valid() && EditorExport::get_singleton()) {
+			EditorExport::get_singleton()->remove_export_platform(export_platform);
+			export_platform.unref();
+		}
+	}
+}
+
+#endif

--- a/modules/screensaver/editor/screensaver_editor_plugin.h
+++ b/modules/screensaver/editor/screensaver_editor_plugin.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  screensaver_editor_plugin.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/export/editor_export_platform.h"
+#include "editor/plugins/editor_plugin.h"
+
+class ScreensaverEditorPlugin : public EditorPlugin {
+	GDCLASS(ScreensaverEditorPlugin, EditorPlugin);
+
+	Ref<EditorExportPlatform> export_platform;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	virtual String get_plugin_name() const override { return "Screensaver"; }
+};
+
+#endif

--- a/modules/screensaver/register_types.cpp
+++ b/modules/screensaver/register_types.cpp
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "core/config/engine.h"
+#include "core/object/message_queue.h"
+#include "screensaver.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/export/windows_screensaver_export_platform.h"
+#include "editor/plugins/editor_plugin.h"
+#include "editor/screensaver_editor_plugin.h"
+#endif
+
+static Screensaver *screensaver_singleton = nullptr;
+
+static void _screensaver_boot() {
+	if (Screensaver::get_singleton()) {
+		Screensaver::get_singleton()->setup_runtime();
+	}
+}
+
+void initialize_screensaver_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		Screensaver::register_project_settings();
+		return;
+	}
+
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformWindowsScreensaver);
+		GDREGISTER_CLASS(ScreensaverEditorPlugin);
+		EditorPlugins::add_by_type<ScreensaverEditorPlugin>();
+		return;
+	}
+#endif
+
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	GDREGISTER_CLASS(Screensaver);
+	screensaver_singleton = memnew(Screensaver);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Screensaver", Screensaver::get_singleton()));
+	if (MessageQueue::get_singleton()) {
+		callable_mp_static(&_screensaver_boot).call_deferred();
+	}
+}
+
+void uninitialize_screensaver_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+#endif
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	Engine::get_singleton()->remove_singleton("Screensaver");
+	if (screensaver_singleton) {
+		memdelete(screensaver_singleton);
+		screensaver_singleton = nullptr;
+	}
+}

--- a/modules/screensaver/register_types.h
+++ b/modules/screensaver/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_screensaver_module(ModuleInitializationLevel p_level);
+void uninitialize_screensaver_module(ModuleInitializationLevel p_level);

--- a/modules/screensaver/screensaver.cpp
+++ b/modules/screensaver/screensaver.cpp
@@ -1,0 +1,853 @@
+/**************************************************************************/
+/*  screensaver.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "screensaver.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/input/input.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "modules/screensaver/screensaver_password.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/texture_rect.h"
+#include "scene/main/canvas_item.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+#include "servers/display_server.h"
+
+#ifdef WINDOWS_ENABLED
+#include <windows.h>
+#endif
+
+Screensaver *Screensaver::singleton = nullptr;
+
+Screensaver *Screensaver::get_singleton() {
+	return singleton;
+}
+
+void Screensaver::register_project_settings() {
+	GLOBAL_DEF_BASIC("blazium/screensaver/enabled", false);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/screensaver/configure_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), String());
+	GLOBAL_DEF_BASIC("blazium/screensaver/password_enabled", false);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/screensaver/unlock_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), String());
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/screensaver/change_password_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn"), String());
+	GLOBAL_DEF_BASIC("blazium/screensaver/lock_workstation_on_exit", false);
+	GLOBAL_DEF_BASIC("blazium/screensaver/quit_on_input", true);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/screensaver/quit_on_mouse_move_threshold", PROPERTY_HINT_RANGE, "0,64,1"), 5);
+	GLOBAL_DEF_BASIC("blazium/screensaver/cover_all_screens", true);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/screensaver/cover_mode", PROPERTY_HINT_ENUM, "single,virtual,clone"), "virtual");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/screensaver/screen", PROPERTY_HINT_RANGE, "-1,16,1"), -1);
+}
+
+Screensaver::Screensaver() {
+	singleton = this;
+}
+
+Screensaver::~Screensaver() {
+	_disconnect_frame_hook();
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void Screensaver::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_mode"), &Screensaver::get_mode);
+	ClassDB::bind_method(D_METHOD("is_preview"), &Screensaver::is_preview);
+	ClassDB::bind_method(D_METHOD("is_password_enabled"), &Screensaver::is_password_enabled);
+	ClassDB::bind_method(D_METHOD("set_password_enabled", "enabled"), &Screensaver::set_password_enabled);
+	ClassDB::bind_method(D_METHOD("has_password"), &Screensaver::has_password);
+	ClassDB::bind_method(D_METHOD("request_exit"), &Screensaver::request_exit);
+	ClassDB::bind_method(D_METHOD("verify_password", "plain"), &Screensaver::verify_password);
+	ClassDB::bind_method(D_METHOD("set_password", "old_plain", "new_plain"), &Screensaver::set_password);
+	ClassDB::bind_method(D_METHOD("clear_password", "current_plain"), &Screensaver::clear_password);
+
+	ADD_SIGNAL(MethodInfo("unlock_succeeded"));
+	ADD_SIGNAL(MethodInfo("unlock_failed"));
+	ADD_SIGNAL(MethodInfo("password_changed"));
+
+	BIND_ENUM_CONSTANT(MODE_DISABLED);
+	BIND_ENUM_CONSTANT(MODE_RUN);
+	BIND_ENUM_CONSTANT(MODE_PREVIEW);
+	BIND_ENUM_CONSTANT(MODE_CONFIGURE);
+	BIND_ENUM_CONSTANT(MODE_CHANGE_PASSWORD);
+}
+
+Screensaver::Mode Screensaver::get_mode() const {
+	if (!bool(GLOBAL_GET("blazium/screensaver/enabled"))) {
+		return MODE_DISABLED;
+	}
+	return (Mode)ScreensaverCmdline::get_mode();
+}
+
+bool Screensaver::is_preview() const {
+	return get_mode() == MODE_PREVIEW;
+}
+
+bool Screensaver::is_password_enabled() const {
+	if (ScreensaverPassword::has_password_enabled_override()) {
+		return ScreensaverPassword::get_password_enabled();
+	}
+	return bool(GLOBAL_GET("blazium/screensaver/password_enabled"));
+}
+
+void Screensaver::set_password_enabled(bool p_enabled) {
+	ScreensaverPassword::set_password_enabled(p_enabled);
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set_setting("blazium/screensaver/password_enabled", p_enabled);
+	}
+}
+
+bool Screensaver::has_password() const {
+	return ScreensaverPassword::has_password();
+}
+
+bool Screensaver::verify_password(const String &p_plain) const {
+	return ScreensaverPassword::verify(p_plain);
+}
+
+Error Screensaver::set_password(const String &p_old_plain, const String &p_new_plain) {
+	const Error err = ScreensaverPassword::set_password(p_old_plain, p_new_plain);
+	if (err == OK) {
+		emit_signal(SNAME("password_changed"));
+	}
+	return err;
+}
+
+Error Screensaver::clear_password(const String &p_current_plain) {
+	return ScreensaverPassword::clear_password(p_current_plain);
+}
+
+void Screensaver::_connect_frame_hook() {
+	if (frame_hooked) {
+		return;
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr) {
+		return;
+	}
+	tree->connect("process_frame", callable_mp(this, &Screensaver::process_frame));
+	frame_hooked = true;
+}
+
+void Screensaver::_disconnect_frame_hook() {
+	if (!frame_hooked) {
+		return;
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree) {
+		tree->disconnect("process_frame", callable_mp(this, &Screensaver::process_frame));
+	}
+	frame_hooked = false;
+}
+
+void Screensaver::setup_runtime() {
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	ScreensaverCmdline::apply_default_mode_if_scr();
+	if (get_mode() == MODE_DISABLED) {
+		return;
+	}
+
+	_connect_frame_hook();
+
+	if (get_mode() == MODE_RUN && Input::get_singleton()) {
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_HIDDEN);
+	}
+
+	if (get_mode() == MODE_RUN) {
+		ScreensaverCmdline::ingest_from_os_command_line();
+		_ensure_run_chrome();
+		_apply_run_screens();
+		_hide_restricted_main_if_needed();
+	} else if (get_mode() == MODE_PREVIEW) {
+		_hide_restricted_main_if_needed();
+		_size_preview_to_parent();
+	} else if (get_mode() == MODE_CONFIGURE) {
+		_show_configure_instance();
+		_load_or_show_scene("blazium/screensaver/configure_scene", &Screensaver::_show_configure_dialog);
+	} else if (get_mode() == MODE_CHANGE_PASSWORD) {
+		_show_configure_instance();
+		_load_or_show_scene("blazium/screensaver/change_password_scene", &Screensaver::_show_change_password_dialog);
+	}
+}
+
+#ifdef WINDOWS_ENABLED
+static void _native_place_hwnd(HWND p_hwnd, const Rect2i &p_os_rect) {
+	if (p_hwnd == nullptr || p_os_rect.size.width <= 0 || p_os_rect.size.height <= 0) {
+		return;
+	}
+
+	LONG_PTR style = GetWindowLongPtr(p_hwnd, GWL_STYLE);
+	style &= ~(WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+	style |= WS_POPUP | WS_VISIBLE;
+	SetWindowLongPtr(p_hwnd, GWL_STYLE, style);
+
+	LONG_PTR ex = GetWindowLongPtr(p_hwnd, GWL_EXSTYLE);
+	ex |= WS_EX_TOPMOST;
+	SetWindowLongPtr(p_hwnd, GWL_EXSTYLE, ex);
+
+	SetWindowPos(p_hwnd, HWND_TOPMOST, p_os_rect.position.x, p_os_rect.position.y, p_os_rect.size.width, p_os_rect.size.height, SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+}
+
+static HWND _main_hwnd() {
+	DisplayServer *ds = DisplayServer::get_singleton();
+	if (ds == nullptr) {
+		return nullptr;
+	}
+	return (HWND)ds->window_get_native_handle(DisplayServer::WINDOW_HANDLE);
+}
+#endif
+
+void Screensaver::_place_hwnd(const Rect2i &p_os_rect) {
+	if (p_os_rect.size.width <= 0 || p_os_rect.size.height <= 0) {
+		return;
+	}
+
+#ifdef WINDOWS_ENABLED
+	const HWND hwnd = _main_hwnd();
+	_native_place_hwnd(hwnd, p_os_rect);
+	_sync_root_window_size(p_os_rect.size);
+	_native_place_hwnd(hwnd, p_os_rect);
+	if (!place_log_written) {
+		_write_place_log(p_os_rect, (int64_t)hwnd);
+		place_log_written = true;
+	}
+#else
+	_sync_root_window_size(p_os_rect.size);
+#endif
+}
+
+void Screensaver::_place_window_hwnd(Window *p_window, const Rect2i &p_os_rect) {
+	if (p_window == nullptr || p_os_rect.size.width <= 0 || p_os_rect.size.height <= 0) {
+		return;
+	}
+
+#ifdef WINDOWS_ENABLED
+	DisplayServer *ds = DisplayServer::get_singleton();
+	if (ds == nullptr) {
+		return;
+	}
+	const DisplayServer::WindowID id = p_window->get_window_id();
+	if (id == DisplayServer::INVALID_WINDOW_ID) {
+		return;
+	}
+	const HWND hwnd = (HWND)ds->window_get_native_handle(DisplayServer::WINDOW_HANDLE, id);
+	_native_place_hwnd(hwnd, p_os_rect);
+#endif
+}
+
+void Screensaver::_sync_root_window_size(const Size2i &p_size) {
+	if (p_size.width <= 0 || p_size.height <= 0) {
+		return;
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	Window *root = tree->get_root();
+	const Size2i max = root->get_max_size();
+	if (max != Size2i() && (max.x < p_size.x || max.y < p_size.y)) {
+		root->set_max_size(Size2i());
+	}
+	if (root->get_min_size() != p_size) {
+		root->set_min_size(p_size);
+	}
+	if (root->get_max_size() != p_size) {
+		root->set_max_size(p_size);
+	}
+	if (root->get_size() != p_size) {
+		root->set_size(p_size);
+	}
+}
+
+void Screensaver::_write_place_log(const Rect2i &p_target, int64_t p_hwnd) {
+	if (OS::get_singleton() == nullptr) {
+		return;
+	}
+	String temp = OS::get_singleton()->get_environment("TEMP");
+	if (temp.is_empty()) {
+		temp = OS::get_singleton()->get_environment("TMP");
+	}
+	if (temp.is_empty()) {
+		return;
+	}
+	const String path = temp.path_join("blazium_screensaver_place.txt");
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	if (f.is_null()) {
+		return;
+	}
+	f->store_line("cover=" + ScreensaverCmdline::resolved_cover_mode());
+	f->store_line(String("host_launch=") + (ScreensaverCmdline::is_host_screensaver_launch() ? "true" : "false"));
+	f->store_line("screen_override=" + itos(ScreensaverCmdline::get_target_screen_override()));
+	f->store_line("screen=" + itos(ScreensaverCmdline::resolved_target_screen(0)));
+#ifdef WINDOWS_ENABLED
+	f->store_line(String("cmdline=") + String::utf16((const char16_t *)GetCommandLineW()));
+#endif
+	if (OS::get_singleton()) {
+		f->store_line("env_screen=" + OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_SCREEN"));
+		f->store_line("env_cover=" + OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_COVER"));
+	}
+	const int count = ScreensaverCmdline::os_monitor_count();
+	f->store_line("os_monitor_count=" + itos(count));
+	for (int i = 0; i < count; i++) {
+		const Rect2i r = ScreensaverCmdline::monitor_os_rect(i);
+		f->store_line(vformat("monitor[%d]=%d,%d %dx%d", i, r.position.x, r.position.y, r.size.width, r.size.height));
+	}
+	f->store_line(vformat("target=%d,%d %dx%d", p_target.position.x, p_target.position.y, p_target.size.width, p_target.size.height));
+	f->store_line(vformat("hwnd=0x%x", (uint64_t)p_hwnd));
+#ifdef WINDOWS_ENABLED
+	RECT got = {};
+	if (p_hwnd) {
+		GetWindowRect((HWND)p_hwnd, &got);
+	}
+	f->store_line(vformat("GetWindowRect=%d,%d %dx%d", (int)got.left, (int)got.top, (int)(got.right - got.left), (int)(got.bottom - got.top)));
+	f->store_line(vformat("virtual=%d,%d %dx%d", ScreensaverCmdline::virtual_screen_rect().position.x, ScreensaverCmdline::virtual_screen_rect().position.y, ScreensaverCmdline::virtual_screen_rect().size.width, ScreensaverCmdline::virtual_screen_rect().size.height));
+#endif
+}
+
+bool Screensaver::_virtual_span_clipped(const Rect2i &p_want) const {
+#ifdef WINDOWS_ENABLED
+	const HWND hwnd = _main_hwnd();
+	if (hwnd == nullptr || p_want.size.width <= 0 || p_want.size.height <= 0) {
+		return false;
+	}
+	if (ScreensaverCmdline::os_monitor_count() < 2) {
+		return false;
+	}
+	RECT got = {};
+	GetWindowRect(hwnd, &got);
+	const int got_w = got.right - got.left;
+	const int got_h = got.bottom - got.top;
+	if (got_w <= 0 || got_h <= 0) {
+		return false;
+	}
+	return (got_w * 2 < p_want.size.width) || (got_h * 2 < p_want.size.height);
+#else
+	return false;
+#endif
+}
+
+void Screensaver::_pin_window_to_screen(int p_screen) {
+	const int count = ScreensaverCmdline::os_monitor_count();
+	const int screen = ScreensaverCmdline::normalize_screen_index(p_screen, count);
+	if (screen < 0) {
+		return;
+	}
+	if (count > 0 && screen >= count) {
+		return;
+	}
+
+	_place_hwnd(ScreensaverCmdline::cover_os_rect(screen));
+}
+
+void Screensaver::_apply_run_screens() {
+	const String cover = ScreensaverCmdline::resolved_cover_mode();
+	const int count = ScreensaverCmdline::os_monitor_count();
+	const int screen = ScreensaverCmdline::normalize_screen_index(ScreensaverCmdline::resolved_target_screen(0), count);
+
+	if (cover == "virtual") {
+		const Rect2i virt = ScreensaverCmdline::virtual_os_rect();
+		_place_hwnd(virt);
+		if (_virtual_span_clipped(virt)) {
+			_pin_window_to_screen(0);
+			if (!clones_spawned) {
+				_spawn_clone_windows(0);
+				clones_spawned = true;
+			}
+			_place_clone_windows();
+		}
+	} else if (cover == "single" || cover == "clone") {
+		_pin_window_to_screen(screen);
+		if (cover == "clone") {
+			if (!clones_spawned) {
+				_spawn_clone_windows(screen >= 0 ? screen : 0);
+				clones_spawned = true;
+			}
+			_place_clone_windows();
+		}
+	}
+}
+
+void Screensaver::_place_clone_windows() {
+	for (int i = 0; i < clone_covers.size(); i++) {
+		if (clone_covers[i].window == nullptr) {
+			continue;
+		}
+		_place_window_hwnd(clone_covers[i].window, ScreensaverCmdline::cover_os_rect(clone_covers[i].screen));
+	}
+}
+
+void Screensaver::_spawn_clone_windows(int p_skip_screen) {
+	DisplayServer *ds = DisplayServer::get_singleton();
+	SceneTree *tree = SceneTree::get_singleton();
+	if (ds == nullptr || tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	const String name = ds->get_name();
+	if (name == "headless" || name == "dummy") {
+		return;
+	}
+
+	Window *root = tree->get_root();
+	const int count = ScreensaverCmdline::os_monitor_count();
+	const Ref<Texture2D> tex = root->get_texture();
+
+	for (int i = 0; i < count; i++) {
+		if (i == p_skip_screen) {
+			continue;
+		}
+		bool exists = false;
+		for (int c = 0; c < clone_covers.size(); c++) {
+			if (clone_covers[c].screen == i) {
+				exists = true;
+				break;
+			}
+		}
+		if (exists) {
+			continue;
+		}
+
+		Window *clone = memnew(Window);
+		clone->set_flag(Window::FLAG_BORDERLESS, true);
+		clone->set_flag(Window::FLAG_ALWAYS_ON_TOP, true);
+		TextureRect *rect = memnew(TextureRect);
+		rect->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+		rect->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
+		rect->set_stretch_mode(TextureRect::STRETCH_SCALE);
+		rect->set_texture(tex);
+		clone->add_child(rect);
+		root->add_child(clone);
+		clone->set_mode(Window::MODE_WINDOWED);
+		clone->show();
+		const Rect2i os_rect = ScreensaverCmdline::cover_os_rect(i);
+		if (os_rect.size.width > 0 && os_rect.size.height > 0) {
+			clone->set_min_size(os_rect.size);
+			clone->set_max_size(os_rect.size);
+			clone->set_size(os_rect.size);
+		}
+		_place_window_hwnd(clone, os_rect);
+		CloneCover cover;
+		cover.window = clone;
+		cover.screen = i;
+		clone_covers.push_back(cover);
+	}
+}
+
+bool Screensaver::_is_restricted_scene_path(const String &p_path) const {
+	if (p_path.is_empty()) {
+		return false;
+	}
+	const String unlock = String(GLOBAL_GET("blazium/screensaver/unlock_scene")).strip_edges();
+	const String configure = String(GLOBAL_GET("blazium/screensaver/configure_scene")).strip_edges();
+	const String change = String(GLOBAL_GET("blazium/screensaver/change_password_scene")).strip_edges();
+	return p_path == unlock || p_path == configure || p_path == change;
+}
+
+void Screensaver::_hide_current_scene() {
+	SceneTree *tree = SceneTree::get_singleton();
+	Node *cur = tree ? tree->get_current_scene() : nullptr;
+	if (cur == nullptr) {
+		return;
+	}
+	CanvasItem *ci = Object::cast_to<CanvasItem>(cur);
+	if (ci) {
+		ci->set_visible(false);
+		return;
+	}
+	for (int i = 0; i < cur->get_child_count(); i++) {
+		CanvasItem *child = Object::cast_to<CanvasItem>(cur->get_child(i));
+		if (child) {
+			child->set_visible(false);
+		}
+	}
+}
+
+void Screensaver::_hide_restricted_main_if_needed() {
+	const String main = String(GLOBAL_GET("application/run/main_scene")).strip_edges();
+	if (!_is_restricted_scene_path(main)) {
+		return;
+	}
+	_hide_current_scene();
+}
+
+void Screensaver::_size_preview_to_parent() {
+	const int64_t parent = ScreensaverCmdline::get_parent_hwnd();
+	if (parent == 0) {
+		return;
+	}
+
+#ifdef WINDOWS_ENABLED
+	const HWND hwnd = _main_hwnd();
+	const HWND parent_hwnd = (HWND)(INT_PTR)parent;
+	if (hwnd == nullptr || !ScreensaverCmdline::is_hwnd_valid(parent)) {
+		_sync_root_window_size(ScreensaverCmdline::parent_client_size());
+		return;
+	}
+
+	LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
+	style &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_OVERLAPPED);
+	style |= WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+	SetWindowLongPtr(hwnd, GWL_STYLE, style);
+
+	LONG_PTR ex = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+	ex &= ~(WS_EX_APPWINDOW | WS_EX_TOPMOST | WS_EX_WINDOWEDGE | WS_EX_DLGMODALFRAME);
+	ex |= WS_EX_TOOLWINDOW;
+	SetWindowLongPtr(hwnd, GWL_EXSTYLE, ex);
+
+	if (GetParent(hwnd) != parent_hwnd) {
+		SetParent(hwnd, parent_hwnd);
+	}
+
+	RECT rc = {};
+	GetClientRect(parent_hwnd, &rc);
+	const int width = rc.right - rc.left;
+	const int height = rc.bottom - rc.top;
+	SetWindowPos(hwnd, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_FRAMECHANGED | SWP_NOACTIVATE);
+	_sync_root_window_size(Size2i(width, height));
+#else
+	_sync_root_window_size(ScreensaverCmdline::parent_client_size());
+#endif
+}
+
+void Screensaver::_ensure_run_chrome() {
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	Window *root = tree->get_root();
+	root->set_flag(Window::FLAG_BORDERLESS, true);
+	root->set_flag(Window::FLAG_ALWAYS_ON_TOP, true);
+}
+
+void Screensaver::_ensure_dialog_chrome() {
+	if (Input::get_singleton()) {
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+	}
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	Window *root = tree->get_root();
+	root->set_flag(Window::FLAG_BORDERLESS, false);
+	root->set_flag(Window::FLAG_ALWAYS_ON_TOP, false);
+	root->set_min_size(Size2i());
+	root->set_max_size(Size2i());
+	if (root->get_size().x > 520 || root->get_size().y > 360) {
+		root->set_size(Size2i(480, 320));
+	}
+}
+
+void Screensaver::_raise_dialog_hwnd() {
+#ifdef WINDOWS_ENABLED
+	const HWND hwnd = _main_hwnd();
+	if (hwnd == nullptr) {
+		return;
+	}
+	const int64_t parent = ScreensaverCmdline::get_parent_hwnd();
+	if (parent != 0 && ScreensaverCmdline::is_hwnd_valid(parent)) {
+		const HWND owner = (HWND)(INT_PTR)parent;
+		if (GetWindowLongPtr(hwnd, GWLP_HWNDPARENT) != (LONG_PTR)owner) {
+			SetWindowLongPtr(hwnd, GWLP_HWNDPARENT, (LONG_PTR)owner);
+		}
+	}
+	ShowWindow(hwnd, SW_SHOW);
+	ShowWindow(hwnd, SW_RESTORE);
+	SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+	SetForegroundWindow(hwnd);
+#endif
+}
+
+void Screensaver::_show_configure_instance() {
+	_prepare_dialog_window();
+}
+
+void Screensaver::_prepare_dialog_window() {
+	_hide_current_scene();
+	_ensure_dialog_chrome();
+	_raise_dialog_hwnd();
+}
+
+void Screensaver::_load_or_show_scene(const String &p_setting, void (Screensaver::*p_builtin)()) {
+	const String scene = String(GLOBAL_GET(p_setting)).strip_edges();
+	const String unlock = String(GLOBAL_GET("blazium/screensaver/unlock_scene")).strip_edges();
+	const bool is_unlock = p_setting == "blazium/screensaver/unlock_scene";
+
+	if (is_unlock) {
+		if (get_mode() != MODE_RUN || !is_password_enabled() || !has_password()) {
+			return;
+		}
+	} else {
+		_prepare_dialog_window();
+		if (!scene.is_empty() && !unlock.is_empty() && scene == unlock) {
+			(this->*p_builtin)();
+			return;
+		}
+	}
+
+	if (!scene.is_empty() && ResourceLoader::exists(scene)) {
+		SceneTree *tree = SceneTree::get_singleton();
+		if (tree && tree->change_scene_to_file(scene) == OK) {
+			_raise_dialog_hwnd();
+			return;
+		}
+	}
+
+	if (!is_unlock) {
+		_prepare_dialog_window();
+	}
+	(this->*p_builtin)();
+	if (!is_unlock) {
+		_raise_dialog_hwnd();
+	}
+}
+
+void Screensaver::request_exit() {
+	if (get_mode() == MODE_PREVIEW) {
+		return;
+	}
+	if (get_mode() != MODE_RUN) {
+		_finish_exit();
+		return;
+	}
+	if (is_password_enabled() && has_password()) {
+		if (!unlock_open) {
+			unlock_open = true;
+			_load_or_show_scene("blazium/screensaver/unlock_scene", &Screensaver::_show_unlock_dialog);
+		}
+		return;
+	}
+	_finish_exit();
+}
+
+void Screensaver::_finish_exit() {
+#ifdef WINDOWS_ENABLED
+	if (bool(GLOBAL_GET("blazium/screensaver/lock_workstation_on_exit"))) {
+		LockWorkStation();
+	}
+#endif
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree) {
+		tree->quit();
+	}
+}
+
+bool Screensaver::_should_quit_on_input() const {
+	return get_mode() == MODE_RUN && bool(GLOBAL_GET("blazium/screensaver/quit_on_input")) && !unlock_open;
+}
+
+void Screensaver::process_frame() {
+	if (get_mode() == MODE_RUN) {
+		_ensure_run_chrome();
+		_apply_run_screens();
+	} else if (get_mode() == MODE_PREVIEW) {
+		_size_preview_to_parent();
+	} else if (get_mode() == MODE_CONFIGURE || get_mode() == MODE_CHANGE_PASSWORD) {
+		_ensure_dialog_chrome();
+		_raise_dialog_hwnd();
+	}
+
+	if (!_should_quit_on_input() || Input::get_singleton() == nullptr || DisplayServer::get_singleton() == nullptr) {
+		return;
+	}
+
+	if (!input_armed) {
+		input_armed = true;
+		mouse_origin = DisplayServer::get_singleton()->mouse_get_position();
+		mouse_origin_set = true;
+		return;
+	}
+
+	if (Input::get_singleton()->is_anything_pressed()) {
+		request_exit();
+		return;
+	}
+
+	const int threshold = int(GLOBAL_GET("blazium/screensaver/quit_on_mouse_move_threshold"));
+	const Vector2 pos = DisplayServer::get_singleton()->mouse_get_position();
+	if (mouse_origin_set && pos.distance_to(mouse_origin) >= threshold) {
+		request_exit();
+	}
+}
+
+void Screensaver::_show_configure_dialog() {
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	AcceptDialog *dlg = memnew(AcceptDialog);
+	dlg->set_title("Screensaver Setup");
+	dlg->set_ok_button_text("OK");
+	VBoxContainer *vb = memnew(VBoxContainer);
+	CheckBox *pw = memnew(CheckBox);
+	pw->set_text("Password protect");
+	pw->set_pressed(is_password_enabled());
+	pw->connect("toggled", callable_mp(this, &Screensaver::_on_configure_password_toggled));
+	vb->add_child(pw);
+	Button *change = memnew(Button);
+	change->set_text("Change Password");
+	change->connect(SceneStringName(pressed), callable_mp(this, &Screensaver::_on_configure_change_password));
+	vb->add_child(change);
+	dlg->add_child(vb);
+	tree->get_root()->add_child(dlg);
+	dlg->popup_centered();
+	dlg->connect("confirmed", callable_mp(this, &Screensaver::_finish_exit));
+	dlg->connect("canceled", callable_mp(this, &Screensaver::_finish_exit));
+}
+
+void Screensaver::_on_configure_password_toggled(bool p_pressed) {
+	set_password_enabled(p_pressed);
+}
+
+void Screensaver::_on_configure_change_password() {
+	_show_change_password_dialog();
+}
+
+void Screensaver::_show_unlock_dialog() {
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	if (Input::get_singleton()) {
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+	}
+	AcceptDialog *dlg = memnew(AcceptDialog);
+	dlg->set_name("UnlockDialog");
+	dlg->set_title("Unlock Screensaver");
+	dlg->set_ok_button_text("Unlock");
+	VBoxContainer *vb = memnew(VBoxContainer);
+	LineEdit *edit = memnew(LineEdit);
+	edit->set_secret(true);
+	edit->set_placeholder("Password");
+	edit->set_name("Password");
+	vb->add_child(edit);
+	Label *status = memnew(Label);
+	status->set_name("UnlockStatus");
+	status->set_visible(false);
+	vb->add_child(status);
+	dlg->add_child(vb);
+	tree->get_root()->add_child(dlg);
+	dlg->set_meta("password_edit", edit);
+	dlg->popup_centered();
+	dlg->connect("confirmed", callable_mp(this, &Screensaver::_on_unlock_accepted));
+}
+
+void Screensaver::_on_unlock_accepted() {
+	SceneTree *tree = SceneTree::get_singleton();
+	Node *root = tree ? tree->get_root() : nullptr;
+	LineEdit *edit = nullptr;
+	if (root) {
+		edit = Object::cast_to<LineEdit>(root->find_child("Password", true, false));
+	}
+	const String plain = edit ? edit->get_text() : String();
+	if (verify_password(plain)) {
+		emit_signal(SNAME("unlock_succeeded"));
+		_finish_exit();
+	} else {
+		emit_signal(SNAME("unlock_failed"));
+		if (root) {
+			Label *status = Object::cast_to<Label>(root->find_child("UnlockStatus", true, false));
+			if (status) {
+				status->set_text("Incorrect password");
+				status->set_visible(true);
+			}
+			AcceptDialog *dlg = Object::cast_to<AcceptDialog>(root->find_child("UnlockDialog", true, false));
+			if (dlg) {
+				dlg->popup_centered();
+			}
+		}
+	}
+}
+
+void Screensaver::_show_change_password_dialog() {
+	SceneTree *tree = SceneTree::get_singleton();
+	if (tree == nullptr || tree->get_root() == nullptr) {
+		return;
+	}
+	AcceptDialog *dlg = memnew(AcceptDialog);
+	dlg->set_title("Change Screensaver Password");
+	dlg->set_ok_button_text("Save");
+	VBoxContainer *vb = memnew(VBoxContainer);
+	LineEdit *current = memnew(LineEdit);
+	current->set_secret(true);
+	current->set_placeholder("Current password");
+	current->set_name("CurrentPassword");
+	vb->add_child(current);
+	LineEdit *next = memnew(LineEdit);
+	next->set_secret(true);
+	next->set_placeholder("New password (empty to clear)");
+	next->set_name("NewPassword");
+	vb->add_child(next);
+	LineEdit *confirm = memnew(LineEdit);
+	confirm->set_secret(true);
+	confirm->set_placeholder("Confirm new password");
+	confirm->set_name("ConfirmPassword");
+	vb->add_child(confirm);
+	dlg->add_child(vb);
+	tree->get_root()->add_child(dlg);
+	dlg->popup_centered();
+	dlg->connect("confirmed", callable_mp(this, &Screensaver::_on_change_password_accepted));
+	if (get_mode() == MODE_CHANGE_PASSWORD) {
+		dlg->connect("canceled", callable_mp(this, &Screensaver::_finish_exit));
+	}
+}
+
+void Screensaver::_on_change_password_accepted() {
+	SceneTree *tree = SceneTree::get_singleton();
+	Node *root = tree ? tree->get_root() : nullptr;
+	if (root == nullptr) {
+		return;
+	}
+	LineEdit *current = Object::cast_to<LineEdit>(root->find_child("CurrentPassword", true, false));
+	LineEdit *next = Object::cast_to<LineEdit>(root->find_child("NewPassword", true, false));
+	LineEdit *confirm = Object::cast_to<LineEdit>(root->find_child("ConfirmPassword", true, false));
+	const String old_plain = current ? current->get_text() : String();
+	const String new_plain = next ? next->get_text() : String();
+	const String confirm_plain = confirm ? confirm->get_text() : String();
+	if (new_plain != confirm_plain) {
+		return;
+	}
+	if (set_password(old_plain, new_plain) != OK) {
+		return;
+	}
+	if (get_mode() == MODE_CHANGE_PASSWORD) {
+		_finish_exit();
+	}
+}

--- a/modules/screensaver/screensaver.h
+++ b/modules/screensaver/screensaver.h
@@ -1,0 +1,125 @@
+/**************************************************************************/
+/*  screensaver.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "core/templates/vector.h"
+#include "modules/screensaver/screensaver_cmdline.h"
+
+class AcceptDialog;
+class CheckBox;
+class LineEdit;
+class Window;
+
+class Screensaver : public Object {
+	GDCLASS(Screensaver, Object);
+
+public:
+	enum Mode {
+		MODE_DISABLED = ScreensaverCmdline::MODE_NONE,
+		MODE_RUN = ScreensaverCmdline::MODE_RUN,
+		MODE_PREVIEW = ScreensaverCmdline::MODE_PREVIEW,
+		MODE_CONFIGURE = ScreensaverCmdline::MODE_CONFIGURE,
+		MODE_CHANGE_PASSWORD = ScreensaverCmdline::MODE_CHANGE_PASSWORD,
+	};
+
+	static Screensaver *get_singleton();
+
+	Mode get_mode() const;
+	bool is_preview() const;
+	bool is_password_enabled() const;
+	void set_password_enabled(bool p_enabled);
+	bool has_password() const;
+	void request_exit();
+	bool verify_password(const String &p_plain) const;
+	Error set_password(const String &p_old_plain, const String &p_new_plain);
+	Error clear_password(const String &p_current_plain);
+
+	void process_frame();
+	void setup_runtime();
+
+	static void register_project_settings();
+
+	Screensaver();
+	~Screensaver();
+
+protected:
+	static void _bind_methods();
+
+private:
+	static Screensaver *singleton;
+
+	struct CloneCover {
+		Window *window = nullptr;
+		int screen = -1;
+	};
+
+	bool frame_hooked = false;
+	bool unlock_open = false;
+	bool mouse_origin_set = false;
+	Vector2 mouse_origin;
+	bool input_armed = false;
+	bool clones_spawned = false;
+	bool place_log_written = false;
+	Vector<CloneCover> clone_covers;
+
+	void _connect_frame_hook();
+	void _disconnect_frame_hook();
+	void _apply_run_screens();
+	void _place_hwnd(const Rect2i &p_os_rect);
+	void _place_window_hwnd(Window *p_window, const Rect2i &p_os_rect);
+	void _pin_window_to_screen(int p_screen);
+	void _sync_root_window_size(const Size2i &p_size);
+	void _write_place_log(const Rect2i &p_target, int64_t p_hwnd);
+	bool _virtual_span_clipped(const Rect2i &p_want) const;
+	void _spawn_clone_windows(int p_skip_screen);
+	void _place_clone_windows();
+	void _load_or_show_scene(const String &p_setting, void (Screensaver::*p_builtin)());
+	void _hide_current_scene();
+	void _hide_restricted_main_if_needed();
+	void _size_preview_to_parent();
+	bool _is_restricted_scene_path(const String &p_path) const;
+	void _ensure_run_chrome();
+	void _ensure_dialog_chrome();
+	void _raise_dialog_hwnd();
+	void _show_configure_instance();
+	void _prepare_dialog_window();
+	void _show_configure_dialog();
+	void _show_unlock_dialog();
+	void _show_change_password_dialog();
+	void _finish_exit();
+	void _on_configure_password_toggled(bool p_pressed);
+	void _on_configure_change_password();
+	void _on_unlock_accepted();
+	void _on_change_password_accepted();
+	bool _should_quit_on_input() const;
+};
+
+VARIANT_ENUM_CAST(Screensaver::Mode);

--- a/modules/screensaver/screensaver_cmdline.cpp
+++ b/modules/screensaver/screensaver_cmdline.cpp
@@ -1,0 +1,813 @@
+/**************************************************************************/
+/*  screensaver_cmdline.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "screensaver_cmdline.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+
+#ifdef WINDOWS_ENABLED
+// clang-format off
+#include <windows.h>
+#include <shellapi.h>
+#include <tlhelp32.h>
+// clang-format on
+#endif
+
+ScreensaverCmdline::Mode ScreensaverCmdline::mode = ScreensaverCmdline::MODE_NONE;
+int64_t ScreensaverCmdline::parent_hwnd = 0;
+String ScreensaverCmdline::cover_override;
+int ScreensaverCmdline::screen_override = -1;
+bool ScreensaverCmdline::virtual_rect_overridden = false;
+Rect2i ScreensaverCmdline::virtual_rect_override;
+bool ScreensaverCmdline::monitor_rect_overridden = false;
+int ScreensaverCmdline::monitor_rect_override_index = -1;
+Rect2i ScreensaverCmdline::monitor_rect_override;
+bool ScreensaverCmdline::os_monitor_count_overridden = false;
+int ScreensaverCmdline::os_monitor_count_override = 0;
+bool ScreensaverCmdline::host_launch_overridden = false;
+bool ScreensaverCmdline::host_launch_override = false;
+bool ScreensaverCmdline::executable_is_scr_overridden = false;
+bool ScreensaverCmdline::executable_is_scr_override = false;
+bool ScreensaverCmdline::hwnd_valid_overridden = false;
+int64_t ScreensaverCmdline::hwnd_valid_override = 0;
+
+ScreensaverCmdline::Mode ScreensaverCmdline::get_mode() {
+	return mode;
+}
+
+int64_t ScreensaverCmdline::get_parent_hwnd() {
+	return parent_hwnd;
+}
+
+void ScreensaverCmdline::reset() {
+	mode = MODE_NONE;
+	parent_hwnd = 0;
+	cover_override = String();
+	screen_override = -1;
+}
+
+void ScreensaverCmdline::apply_default_mode_if_scr() {
+	if (mode != MODE_NONE) {
+		return;
+	}
+	bool is_scr = executable_is_scr_overridden ? executable_is_scr_override : false;
+	if (!executable_is_scr_overridden && OS::get_singleton()) {
+		is_scr = OS::get_singleton()->get_executable_path().get_extension().to_lower() == "scr";
+	}
+	if (is_scr) {
+		mode = MODE_CONFIGURE;
+	}
+}
+
+void ScreensaverCmdline::set_executable_is_scr_for_tests(bool p_scr) {
+	executable_is_scr_overridden = true;
+	executable_is_scr_override = p_scr;
+}
+
+void ScreensaverCmdline::clear_executable_is_scr_for_tests() {
+	executable_is_scr_overridden = false;
+	executable_is_scr_override = false;
+}
+
+void ScreensaverCmdline::set_target_screen(int p_screen) {
+	if (p_screen >= 0) {
+		screen_override = p_screen;
+	}
+}
+
+int ScreensaverCmdline::get_target_screen_override() {
+	return screen_override;
+}
+
+#ifdef WINDOWS_ENABLED
+static DWORD _screensaver_parent_pid() {
+	const DWORD pid = GetCurrentProcessId();
+	HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (snap == INVALID_HANDLE_VALUE) {
+		return 0;
+	}
+	PROCESSENTRY32W pe;
+	pe.dwSize = sizeof(pe);
+	DWORD parent = 0;
+	if (Process32FirstW(snap, &pe)) {
+		do {
+			if (pe.th32ProcessID == pid) {
+				parent = pe.th32ParentProcessID;
+				break;
+			}
+		} while (Process32NextW(snap, &pe));
+	}
+	CloseHandle(snap);
+	return parent;
+}
+
+static String _screensaver_process_basename(DWORD p_pid) {
+	if (p_pid == 0) {
+		return String();
+	}
+	HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, p_pid);
+	if (h == nullptr) {
+		return String();
+	}
+	WCHAR buf[MAX_PATH] = {};
+	DWORD size = MAX_PATH;
+	String name;
+	if (QueryFullProcessImageNameW(h, 0, buf, &size)) {
+		name = String::utf16((const char16_t *)buf).get_file().to_lower();
+	}
+	CloseHandle(h);
+	return name;
+}
+#endif
+
+bool ScreensaverCmdline::is_host_screensaver_launch() {
+	if (host_launch_overridden) {
+		return host_launch_override;
+	}
+	if (parent_hwnd != 0) {
+		return false;
+	}
+#ifdef WINDOWS_ENABLED
+	const String parent = _screensaver_process_basename(_screensaver_parent_pid());
+	if (parent == "explorer.exe" || parent == "winlogon.exe" || parent == "svchost.exe" || parent == "userinit.exe" || parent == "logonui.exe") {
+		return true;
+	}
+	return parent.is_empty();
+#else
+	return false;
+#endif
+}
+
+void ScreensaverCmdline::set_host_screensaver_launch_for_tests(bool p_host) {
+	host_launch_overridden = true;
+	host_launch_override = p_host;
+}
+
+void ScreensaverCmdline::clear_host_screensaver_launch_for_tests() {
+	host_launch_overridden = false;
+	host_launch_override = false;
+}
+
+Vector<Rect2i> ScreensaverCmdline::order_monitor_rects(const Vector<Rect2i> &p_rects, int p_primary) {
+	Vector<Rect2i> ordered;
+	if (p_rects.is_empty()) {
+		return ordered;
+	}
+	int primary = p_primary;
+	if (primary < 0 || primary >= p_rects.size()) {
+		primary = 0;
+		for (int i = 0; i < p_rects.size(); i++) {
+			const Rect2i &r = p_rects[i];
+			if (r.position.x <= 0 && r.position.x + r.size.width > 0 && r.position.y <= 0 && r.position.y + r.size.height > 0) {
+				primary = i;
+				break;
+			}
+		}
+	}
+	ordered.push_back(p_rects[primary]);
+	Vector<int> rest;
+	for (int i = 0; i < p_rects.size(); i++) {
+		if (i != primary) {
+			rest.push_back(i);
+		}
+	}
+	for (int i = 0; i < rest.size(); i++) {
+		for (int j = i + 1; j < rest.size(); j++) {
+			const Rect2i &a = p_rects[rest[i]];
+			const Rect2i &b = p_rects[rest[j]];
+			if (b.position.x < a.position.x || (b.position.x == a.position.x && b.position.y < a.position.y)) {
+				const int tmp = rest[i];
+				rest.write[i] = rest[j];
+				rest.write[j] = tmp;
+			}
+		}
+	}
+	for (int i = 0; i < rest.size(); i++) {
+		ordered.push_back(p_rects[rest[i]]);
+	}
+	return ordered;
+}
+
+bool ScreensaverCmdline::parse_hwnd_token(const String &p_token, int64_t &r_hwnd) {
+	String token = p_token.strip_edges();
+	if (token.is_empty()) {
+		return false;
+	}
+	if (token.begins_with("0x") || token.begins_with("0X")) {
+		r_hwnd = token.hex_to_int();
+		return r_hwnd != 0;
+	}
+	if (!token.is_valid_int()) {
+		return false;
+	}
+	r_hwnd = token.to_int();
+	return r_hwnd != 0;
+}
+
+bool ScreensaverCmdline::is_hwnd_valid(int64_t p_hwnd) {
+	if (p_hwnd == 0) {
+		return false;
+	}
+	if (hwnd_valid_overridden) {
+		return p_hwnd == hwnd_valid_override;
+	}
+#ifdef WINDOWS_ENABLED
+	return IsWindow((HWND)(INT_PTR)p_hwnd) != FALSE;
+#else
+	return false;
+#endif
+}
+
+void ScreensaverCmdline::set_hwnd_valid_for_tests(int64_t p_hwnd) {
+	hwnd_valid_overridden = true;
+	hwnd_valid_override = p_hwnd;
+}
+
+void ScreensaverCmdline::clear_hwnd_valid_for_tests() {
+	hwnd_valid_overridden = false;
+	hwnd_valid_override = 0;
+}
+
+Size2i ScreensaverCmdline::parent_client_size() {
+#ifdef WINDOWS_ENABLED
+	if (parent_hwnd == 0) {
+		return Size2i();
+	}
+	RECT rc = {};
+	if (!GetClientRect((HWND)(INT_PTR)parent_hwnd, &rc)) {
+		return Size2i();
+	}
+	return Size2i(rc.right - rc.left, rc.bottom - rc.top);
+#else
+	return Size2i();
+#endif
+}
+
+static bool _is_switch(const String &p_arg, const char *p_letter) {
+	if (p_arg.length() < 2 || p_arg[0] != '/') {
+		return false;
+	}
+	return p_arg.substr(1, 1).to_upper() == String(p_letter).to_upper() && p_arg.length() == 2;
+}
+
+static bool _split_colon_hwnd(const String &p_arg, const char *p_letter, int64_t &r_hwnd) {
+	if (p_arg.length() < 4 || p_arg[0] != '/') {
+		return false;
+	}
+	if (p_arg.substr(1, 1).to_upper() != String(p_letter).to_upper()) {
+		return false;
+	}
+	if (p_arg[2] != ':') {
+		return false;
+	}
+	return ScreensaverCmdline::parse_hwnd_token(p_arg.substr(3), r_hwnd);
+}
+
+static bool _split_colon_screen(const String &p_arg, int &r_screen) {
+	if (p_arg.length() < 4 || p_arg[0] != '/') {
+		return false;
+	}
+	if (p_arg.substr(1, 1).to_upper() != "S") {
+		return false;
+	}
+	if (p_arg[2] != ':') {
+		return false;
+	}
+	const String token = p_arg.substr(3).strip_edges();
+	if (!token.is_valid_int()) {
+		return false;
+	}
+	const int screen = token.to_int();
+	if (screen < 0) {
+		return false;
+	}
+	r_screen = screen;
+	return true;
+}
+
+static bool _parse_cover_mode(const String &p_token, String &r_mode) {
+	const String token = p_token.strip_edges().to_lower();
+	if (token == "single" || token == "virtual" || token == "clone") {
+		r_mode = token;
+		return true;
+	}
+	return false;
+}
+
+static bool _is_slash_letter(const String &p_arg, const char *p_letter) {
+	if (p_arg.length() < 2 || p_arg[0] != '/') {
+		return false;
+	}
+	return p_arg.substr(1, 1).to_upper() == String(p_letter).to_upper();
+}
+
+static bool _is_screen_index_token(const String &p_token) {
+	if (!p_token.is_valid_int()) {
+		return false;
+	}
+	const int64_t value = p_token.to_int();
+	if (value < 0) {
+		return false;
+	}
+	if (value <= 16) {
+		return true;
+	}
+	return value < ScreensaverCmdline::os_monitor_count();
+}
+
+static bool _try_consume_configure(const String &p_arg, const String &p_next, int64_t &r_hwnd, bool &r_consumed_next) {
+	r_consumed_next = false;
+	r_hwnd = 0;
+	if (!_is_slash_letter(p_arg, "c")) {
+		return false;
+	}
+
+	if (p_arg.length() == 2) {
+		int64_t hwnd = 0;
+		if (ScreensaverCmdline::parse_hwnd_token(p_next, hwnd)) {
+			r_hwnd = hwnd;
+			r_consumed_next = true;
+		}
+		return true;
+	}
+
+	String rest = p_arg.substr(2);
+	if (rest.begins_with(":")) {
+		rest = rest.substr(1);
+	}
+	int64_t hwnd = 0;
+	if (ScreensaverCmdline::parse_hwnd_token(rest, hwnd)) {
+		r_hwnd = hwnd;
+	}
+	return true;
+}
+
+bool ScreensaverCmdline::try_consume(const String &p_arg, const String &p_next, bool &r_consumed_next) {
+	r_consumed_next = false;
+
+	if (p_arg == "-s" || p_arg == "--script" || p_arg == "--screen" || p_arg == "-p" || p_arg == "--project-manager") {
+		return false;
+	}
+
+	if (p_arg == "--screensaver-cover") {
+		String parsed;
+		if (_parse_cover_mode(p_next, parsed)) {
+			cover_override = parsed;
+			r_consumed_next = true;
+		}
+		return true;
+	}
+
+	int screen = 0;
+	if (_split_colon_screen(p_arg, screen)) {
+		mode = MODE_RUN;
+		screen_override = screen;
+		return true;
+	}
+
+	if (_is_switch(p_arg, "s")) {
+		if (_is_screen_index_token(p_next)) {
+			mode = MODE_RUN;
+			screen_override = p_next.to_int();
+			r_consumed_next = true;
+			return true;
+		}
+		int64_t hwnd = 0;
+		if (parse_hwnd_token(p_next, hwnd) && is_hwnd_valid(hwnd)) {
+			mode = MODE_PREVIEW;
+			parent_hwnd = hwnd;
+			r_consumed_next = true;
+			return true;
+		}
+		mode = MODE_RUN;
+		return true;
+	}
+
+	int64_t hwnd = 0;
+	if (_split_colon_hwnd(p_arg, "p", hwnd)) {
+		mode = MODE_PREVIEW;
+		parent_hwnd = hwnd;
+		return true;
+	}
+	if (_is_switch(p_arg, "p")) {
+		mode = MODE_PREVIEW;
+		if (parse_hwnd_token(p_next, hwnd)) {
+			parent_hwnd = hwnd;
+			r_consumed_next = true;
+		}
+		return true;
+	}
+
+	if (_try_consume_configure(p_arg, p_next, hwnd, r_consumed_next)) {
+		mode = MODE_CONFIGURE;
+		parent_hwnd = hwnd;
+		return true;
+	}
+
+	if (_split_colon_hwnd(p_arg, "a", hwnd)) {
+		mode = MODE_CHANGE_PASSWORD;
+		parent_hwnd = hwnd;
+		return true;
+	}
+	if (_is_switch(p_arg, "a")) {
+		mode = MODE_CHANGE_PASSWORD;
+		if (parse_hwnd_token(p_next, hwnd)) {
+			parent_hwnd = hwnd;
+			r_consumed_next = true;
+		}
+		return true;
+	}
+
+	if (parse_hwnd_token(p_arg, hwnd) && is_hwnd_valid(hwnd)) {
+		mode = MODE_PREVIEW;
+		parent_hwnd = hwnd;
+		return true;
+	}
+
+	return false;
+}
+
+String ScreensaverCmdline::resolved_cover_mode() {
+	if (!cover_override.is_empty()) {
+		return cover_override;
+	}
+
+	if (mode == MODE_RUN && screen_override < 0 && is_host_screensaver_launch()) {
+		return "virtual";
+	}
+
+	String cover = "single";
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps) {
+		const String setting = String(ps->get_setting("blazium/screensaver/cover_mode", String())).strip_edges().to_lower();
+		if (setting == "single" || setting == "virtual" || setting == "clone") {
+			cover = setting;
+		} else {
+			cover = bool(ps->get_setting("blazium/screensaver/cover_all_screens", true)) ? String("virtual") : String("single");
+		}
+	}
+
+	if (cover == "virtual") {
+		if (screen_override >= 0) {
+			return "single";
+		}
+		if (ps && int(ps->get_setting("blazium/screensaver/screen", -1)) >= 0) {
+			return "single";
+		}
+	}
+	return cover;
+}
+
+int ScreensaverCmdline::resolved_target_screen(int p_current_screen) {
+	if (screen_override >= 0) {
+		return screen_override;
+	}
+	if (p_current_screen >= 0) {
+		return p_current_screen;
+	}
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps) {
+		const int setting = int(ps->get_setting("blazium/screensaver/screen", -1));
+		if (setting >= 0) {
+			return setting;
+		}
+	}
+	return p_current_screen;
+}
+
+int ScreensaverCmdline::normalize_screen_index(int p_screen, int p_count) {
+	if (p_count <= 0) {
+		return p_screen;
+	}
+	if (p_screen >= 0 && p_screen < p_count) {
+		return p_screen;
+	}
+
+	if (p_screen >= 1 && (p_screen - 1) < p_count) {
+		return p_screen - 1;
+	}
+	return -1;
+}
+
+void ScreensaverCmdline::set_os_monitor_count_for_tests(int p_count) {
+	os_monitor_count_overridden = true;
+	os_monitor_count_override = p_count;
+}
+
+void ScreensaverCmdline::clear_os_monitor_count_for_tests() {
+	os_monitor_count_overridden = false;
+	os_monitor_count_override = 0;
+}
+
+bool ScreensaverCmdline::should_clear_create_position() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps == nullptr || !bool(ps->get_setting("blazium/screensaver/enabled", false))) {
+		return false;
+	}
+	if (mode != MODE_RUN) {
+		return false;
+	}
+	return true;
+}
+
+void ScreensaverCmdline::set_virtual_rect_for_tests(const Rect2i &p_rect) {
+	virtual_rect_overridden = true;
+	virtual_rect_override = p_rect;
+}
+
+void ScreensaverCmdline::clear_virtual_rect_for_tests() {
+	virtual_rect_overridden = false;
+	virtual_rect_override = Rect2i();
+}
+
+void ScreensaverCmdline::set_monitor_rect_for_tests(int p_screen, const Rect2i &p_rect) {
+	monitor_rect_overridden = true;
+	monitor_rect_override_index = p_screen;
+	monitor_rect_override = p_rect;
+}
+
+void ScreensaverCmdline::clear_monitor_rect_for_tests() {
+	monitor_rect_overridden = false;
+	monitor_rect_override_index = -1;
+	monitor_rect_override = Rect2i();
+}
+
+Rect2i ScreensaverCmdline::virtual_screen_rect() {
+	if (virtual_rect_overridden) {
+		return virtual_rect_override;
+	}
+#ifdef WINDOWS_ENABLED
+	return Rect2i(
+			GetSystemMetrics(SM_XVIRTUALSCREEN),
+			GetSystemMetrics(SM_YVIRTUALSCREEN),
+			GetSystemMetrics(SM_CXVIRTUALSCREEN),
+			GetSystemMetrics(SM_CYVIRTUALSCREEN));
+#else
+	return Rect2i(0, 0, 1920, 1080);
+#endif
+}
+
+#ifdef WINDOWS_ENABLED
+struct _ScreensaverMonitorCollect {
+	Vector<Rect2i> rects;
+	int primary = 0;
+};
+
+static BOOL CALLBACK _screensaver_monitor_collect(HMONITOR p_monitor, HDC, LPRECT p_rect, LPARAM p_data) {
+	_ScreensaverMonitorCollect *data = reinterpret_cast<_ScreensaverMonitorCollect *>(p_data);
+	MONITORINFO mi = {};
+	mi.cbSize = sizeof(mi);
+	RECT src = {};
+	if (p_monitor && GetMonitorInfo(p_monitor, &mi)) {
+		src = mi.rcMonitor;
+		if (mi.dwFlags & MONITORINFOF_PRIMARY) {
+			data->primary = data->rects.size();
+		}
+	} else if (p_rect) {
+		src = *p_rect;
+	} else {
+		return TRUE;
+	}
+	data->rects.push_back(Rect2i(src.left, src.top, src.right - src.left, src.bottom - src.top));
+	return TRUE;
+}
+
+static Vector<Rect2i> _os_monitors_primary_first() {
+	_ScreensaverMonitorCollect data;
+	EnumDisplayMonitors(nullptr, nullptr, _screensaver_monitor_collect, reinterpret_cast<LPARAM>(&data));
+	return ScreensaverCmdline::order_monitor_rects(data.rects, data.primary);
+}
+#endif
+
+int ScreensaverCmdline::os_monitor_count() {
+	if (os_monitor_count_overridden) {
+		return os_monitor_count_override;
+	}
+#ifdef WINDOWS_ENABLED
+	return _os_monitors_primary_first().size();
+#else
+	DisplayServer *ds = DisplayServer::get_singleton();
+	if (ds) {
+		return ds->get_screen_count();
+	}
+	return 1;
+#endif
+}
+
+Rect2i ScreensaverCmdline::monitor_os_rect(int p_screen) {
+	if (p_screen < 0) {
+		return Rect2i();
+	}
+	if (monitor_rect_overridden && monitor_rect_override_index == p_screen) {
+		return monitor_rect_override;
+	}
+#ifdef WINDOWS_ENABLED
+	const Vector<Rect2i> ordered = _os_monitors_primary_first();
+	if (p_screen >= ordered.size()) {
+		return Rect2i();
+	}
+	return ordered[p_screen];
+#else
+	return Rect2i();
+#endif
+}
+
+Rect2i ScreensaverCmdline::virtual_os_rect() {
+	return virtual_screen_rect();
+}
+
+Rect2i ScreensaverCmdline::cover_os_rect(int p_screen) {
+	return monitor_os_rect(p_screen);
+}
+
+Rect2i ScreensaverCmdline::cover_rect(int p_screen) {
+	return monitor_rect(p_screen);
+}
+
+Rect2i ScreensaverCmdline::monitor_rect(int p_screen) {
+	if (p_screen < 0) {
+		return Rect2i();
+	}
+	if (monitor_rect_overridden && monitor_rect_override_index == p_screen) {
+		return monitor_rect_override;
+	}
+	const Rect2i os = monitor_os_rect(p_screen);
+	if (os.size.width <= 0 || os.size.height <= 0) {
+		return Rect2i();
+	}
+	const Rect2i virt = virtual_screen_rect();
+	return Rect2i(os.position.x - virt.position.x, os.position.y - virt.position.y, os.size.width, os.size.height);
+}
+
+bool ScreensaverCmdline::should_spawn_clone_windows() {
+	if (mode != MODE_RUN) {
+		return false;
+	}
+	if (resolved_cover_mode() != "clone") {
+		return false;
+	}
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		return false;
+	}
+	DisplayServer *ds = DisplayServer::get_singleton();
+	if (ds == nullptr) {
+		return false;
+	}
+	const String name = ds->get_name();
+	if (name == "headless" || name == "dummy") {
+		return false;
+	}
+	return ScreensaverCmdline::os_monitor_count() >= 2;
+}
+
+static void _ingest_screen_tokens(const Vector<String> &p_args) {
+	for (int i = 0; i < p_args.size(); i++) {
+		const String &a = p_args[i];
+		if ((a == "--screen" || a == "-screen") && i + 1 < p_args.size() && p_args[i + 1].is_valid_int()) {
+			ScreensaverCmdline::set_target_screen(p_args[i + 1].to_int());
+			continue;
+		}
+		if (a.begins_with("--screen=") || a.begins_with("-screen=")) {
+			const String n = a.get_slicec('=', 1);
+			if (n.is_valid_int()) {
+				ScreensaverCmdline::set_target_screen(n.to_int());
+			}
+			continue;
+		}
+		if (a.length() >= 4 && (a[0] == '/' || a[0] == '-') && a.substr(1, 1).to_upper() == "S" && a[2] == ':') {
+			const String n = a.substr(3).strip_edges();
+			if (n.is_valid_int() && n.to_int() >= 0) {
+				ScreensaverCmdline::set_target_screen(n.to_int());
+			}
+			continue;
+		}
+		if ((a == "/s" || a == "/S") && i + 1 < p_args.size() && _is_screen_index_token(p_args[i + 1])) {
+			ScreensaverCmdline::set_target_screen(p_args[i + 1].to_int());
+		}
+	}
+}
+
+void ScreensaverCmdline::ingest_from_os_command_line() {
+#ifdef WINDOWS_ENABLED
+	int argc = 0;
+	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	if (argv) {
+		Vector<String> raw;
+		for (int i = 0; i < argc; i++) {
+			raw.push_back(String::utf16((const char16_t *)argv[i]));
+		}
+		LocalFree(argv);
+		_ingest_screen_tokens(raw);
+	}
+#endif
+	if (OS::get_singleton() == nullptr) {
+		return;
+	}
+	Vector<String> leftover;
+	for (const String &a : OS::get_singleton()->get_cmdline_args()) {
+		leftover.push_back(a);
+	}
+	for (const String &a : OS::get_singleton()->get_cmdline_user_args()) {
+		leftover.push_back(a);
+	}
+	_ingest_screen_tokens(leftover);
+	if (screen_override < 0) {
+		const String env_screen = OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_SCREEN");
+		if (env_screen.is_valid_int() && env_screen.to_int() >= 0) {
+			set_target_screen(env_screen.to_int());
+		}
+	}
+	if (cover_override.is_empty()) {
+		const String env_cover = OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_COVER").strip_edges().to_lower();
+		if (env_cover == "single" || env_cover == "virtual" || env_cover == "clone") {
+			cover_override = env_cover;
+		}
+	}
+}
+
+void ScreensaverCmdline::apply_recorded(DisplayServer::WindowMode &r_window_mode, uint32_t &r_window_flags, int64_t &r_embed_parent_hwnd, Vector2i &r_window_position, Size2i &r_window_size, int &r_screen, bool &r_use_position) {
+	r_use_position = false;
+	ingest_from_os_command_line();
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps == nullptr || !bool(ps->get_setting("blazium/screensaver/enabled", false))) {
+		return;
+	}
+
+	apply_default_mode_if_scr();
+	Mode applied = mode;
+	if (applied == MODE_NONE) {
+		return;
+	}
+
+	switch (applied) {
+		case MODE_RUN: {
+			if (r_screen >= 0 && screen_override < 0) {
+				screen_override = r_screen;
+			}
+			const String cover = resolved_cover_mode();
+			r_window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+			r_embed_parent_hwnd = 0;
+
+			r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+			r_window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
+			if (cover != "virtual") {
+				r_screen = resolved_target_screen(r_screen);
+			}
+		} break;
+		case MODE_PREVIEW: {
+			r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+			r_window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+			r_embed_parent_hwnd = 0;
+			if (parent_hwnd != 0) {
+				r_embed_parent_hwnd = parent_hwnd;
+				// Do not let DisplayServer center a standalone popup; the
+				// preview HWND is reparented as a WS_CHILD at 0,0 in the pane.
+				r_window_position = Vector2i();
+				r_use_position = true;
+				const Size2i parent_size = parent_client_size();
+				if (parent_size.width > 0 && parent_size.height > 0) {
+					r_window_size = parent_size;
+				}
+			}
+		} break;
+		case MODE_CONFIGURE:
+		case MODE_CHANGE_PASSWORD: {
+			r_window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+			r_window_flags &= ~DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+			r_embed_parent_hwnd = 0;
+			if (r_window_size.width <= 0 || r_window_size.height <= 0 || r_window_size.width > 520 || r_window_size.height > 360) {
+				r_window_size = Size2i(480, 320);
+			}
+		} break;
+		default:
+			break;
+	}
+}

--- a/modules/screensaver/screensaver_cmdline.h
+++ b/modules/screensaver/screensaver_cmdline.h
@@ -1,0 +1,124 @@
+/**************************************************************************/
+/*  screensaver_cmdline.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/rect2i.h"
+#include "core/math/vector2i.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+#include "servers/display_server.h"
+
+class ScreensaverCmdline {
+public:
+	enum Mode {
+		MODE_NONE,
+		MODE_RUN,
+		MODE_PREVIEW,
+		MODE_CONFIGURE,
+		MODE_CHANGE_PASSWORD,
+	};
+
+	static Mode get_mode();
+	static int64_t get_parent_hwnd();
+	static void reset();
+
+	static void set_target_screen(int p_screen);
+	static int get_target_screen_override();
+
+	static void ingest_from_os_command_line();
+
+	static bool try_consume(const String &p_arg, const String &p_next, bool &r_consumed_next);
+
+	static void apply_recorded(DisplayServer::WindowMode &r_window_mode, uint32_t &r_window_flags, int64_t &r_embed_parent_hwnd, Vector2i &r_window_position, Size2i &r_window_size, int &r_screen, bool &r_use_position);
+
+	static bool parse_hwnd_token(const String &p_token, int64_t &r_hwnd);
+	static bool is_hwnd_valid(int64_t p_hwnd);
+	static void set_hwnd_valid_for_tests(int64_t p_hwnd);
+	static void clear_hwnd_valid_for_tests();
+	static Size2i parent_client_size();
+
+	static String resolved_cover_mode();
+
+	static bool is_host_screensaver_launch();
+	static void set_host_screensaver_launch_for_tests(bool p_host);
+	static void clear_host_screensaver_launch_for_tests();
+
+	static int resolved_target_screen(int p_current_screen = DisplayServer::SCREEN_PRIMARY);
+
+	static int normalize_screen_index(int p_screen, int p_count);
+
+	static int os_monitor_count();
+	static void set_os_monitor_count_for_tests(int p_count);
+	static void clear_os_monitor_count_for_tests();
+
+	static Vector<Rect2i> order_monitor_rects(const Vector<Rect2i> &p_rects, int p_primary);
+
+	static bool should_clear_create_position();
+
+	static Rect2i virtual_screen_rect();
+
+	static Rect2i virtual_os_rect();
+	static Rect2i monitor_rect(int p_screen);
+
+	static Rect2i monitor_os_rect(int p_screen);
+
+	static Rect2i cover_os_rect(int p_screen);
+
+	static Rect2i cover_rect(int p_screen);
+	static void set_virtual_rect_for_tests(const Rect2i &p_rect);
+	static void clear_virtual_rect_for_tests();
+	static void set_monitor_rect_for_tests(int p_screen, const Rect2i &p_rect);
+	static void clear_monitor_rect_for_tests();
+
+	static bool should_spawn_clone_windows();
+
+	static void apply_default_mode_if_scr();
+	static void set_executable_is_scr_for_tests(bool p_scr);
+	static void clear_executable_is_scr_for_tests();
+
+private:
+	static Mode mode;
+	static int64_t parent_hwnd;
+	static String cover_override;
+	static int screen_override;
+	static bool virtual_rect_overridden;
+	static Rect2i virtual_rect_override;
+	static bool monitor_rect_overridden;
+	static int monitor_rect_override_index;
+	static Rect2i monitor_rect_override;
+	static bool os_monitor_count_overridden;
+	static int os_monitor_count_override;
+	static bool host_launch_overridden;
+	static bool host_launch_override;
+	static bool executable_is_scr_overridden;
+	static bool executable_is_scr_override;
+	static bool hwnd_valid_overridden;
+	static int64_t hwnd_valid_override;
+};

--- a/modules/screensaver/screensaver_password.cpp
+++ b/modules/screensaver/screensaver_password.cpp
@@ -1,0 +1,337 @@
+/**************************************************************************/
+/*  screensaver_password.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "screensaver_password.h"
+
+#include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
+#include "core/io/config_file.h"
+#include "core/os/os.h"
+
+#ifdef WINDOWS_ENABLED
+#include <windows.h>
+#endif
+
+bool ScreensaverPassword::test_override = false;
+String ScreensaverPassword::test_salt;
+String ScreensaverPassword::test_hash;
+bool ScreensaverPassword::test_enabled_override = false;
+bool ScreensaverPassword::test_enabled = false;
+
+String ScreensaverPassword::hash_password(const String &p_plain, const String &p_salt) {
+	const String payload = p_salt + ":" + p_plain;
+	const CharString utf8 = payload.utf8();
+	unsigned char digest[32];
+	CryptoCore::sha256((const uint8_t *)utf8.get_data(), utf8.length(), digest);
+	return String::hex_encode_buffer(digest, 32);
+}
+
+String ScreensaverPassword::generate_salt() {
+	uint8_t bytes[16];
+	CryptoCore::RandomGenerator rng;
+	if (rng.init() != OK || rng.get_random_bytes(bytes, 16) != OK) {
+		const uint64_t ticks = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 1;
+		for (int i = 0; i < 16; i++) {
+			bytes[i] = uint8_t((ticks >> ((i * 5) % 56)) & 0xFF);
+		}
+	}
+	return String::hex_encode_buffer(bytes, 16);
+}
+
+String ScreensaverPassword::storage_key() {
+	String name = "Blazium";
+	if (ProjectSettings::get_singleton()) {
+		const String app = ProjectSettings::get_singleton()->get_setting("application/config/name", "Blazium");
+		if (!String(app).is_empty()) {
+			name = String(app);
+		}
+	}
+	return name.validate_filename();
+}
+
+#ifdef WINDOWS_ENABLED
+static String _reg_path() {
+	return "Software\\Blazium\\Screensaver\\" + ScreensaverPassword::storage_key();
+}
+
+static bool _reg_read(const String &p_value, String &r_out) {
+	HKEY key = nullptr;
+	const Char16String path = _reg_path().utf16();
+	if (RegOpenKeyExW(HKEY_CURRENT_USER, (LPCWSTR)path.get_data(), 0, KEY_READ, &key) != ERROR_SUCCESS) {
+		return false;
+	}
+	wchar_t buf[512];
+	DWORD size = sizeof(buf);
+	DWORD type = 0;
+	const Char16String value = p_value.utf16();
+	const LSTATUS st = RegQueryValueExW(key, (LPCWSTR)value.get_data(), nullptr, &type, (LPBYTE)buf, &size);
+	RegCloseKey(key);
+	if (st != ERROR_SUCCESS || type != REG_SZ) {
+		return false;
+	}
+	r_out = String::utf16((const char16_t *)buf);
+	return !r_out.is_empty();
+}
+
+static Error _reg_write_sz(const String &p_value, const String &p_data) {
+	HKEY key = nullptr;
+	DWORD disp = 0;
+	const Char16String path = _reg_path().utf16();
+	if (RegCreateKeyExW(HKEY_CURRENT_USER, (LPCWSTR)path.get_data(), 0, nullptr, 0, KEY_WRITE, nullptr, &key, &disp) != ERROR_SUCCESS) {
+		return ERR_CANT_CREATE;
+	}
+	const Char16String value = p_value.utf16();
+	const Char16String data = p_data.utf16();
+	const LSTATUS st = RegSetValueExW(key, (LPCWSTR)value.get_data(), 0, REG_SZ, (const BYTE *)data.get_data(), (DWORD)((data.length() + 1) * sizeof(wchar_t)));
+	RegCloseKey(key);
+	return st == ERROR_SUCCESS ? OK : ERR_CANT_CREATE;
+}
+
+static Error _reg_write(const String &p_salt, const String &p_hash) {
+	if (_reg_write_sz("Salt", p_salt) != OK) {
+		return ERR_CANT_CREATE;
+	}
+	return _reg_write_sz("Hash", p_hash);
+}
+
+static Error _reg_delete_value(const String &p_value) {
+	HKEY key = nullptr;
+	const Char16String path = _reg_path().utf16();
+	if (RegOpenKeyExW(HKEY_CURRENT_USER, (LPCWSTR)path.get_data(), 0, KEY_WRITE, &key) != ERROR_SUCCESS) {
+		return OK;
+	}
+	const Char16String value = p_value.utf16();
+	RegDeleteValueW(key, (LPCWSTR)value.get_data());
+	RegCloseKey(key);
+	return OK;
+}
+
+static Error _reg_clear_password() {
+	_reg_delete_value("Salt");
+	_reg_delete_value("Hash");
+	return OK;
+}
+#endif
+
+static String _cfg_path() {
+	return "user://screensaver_password.cfg";
+}
+
+bool ScreensaverPassword::_load(String &r_salt, String &r_hash) {
+	if (test_override) {
+		r_salt = test_salt;
+		r_hash = test_hash;
+		return !r_salt.is_empty() && !r_hash.is_empty();
+	}
+#ifdef WINDOWS_ENABLED
+	if (_reg_read("Salt", r_salt) && _reg_read("Hash", r_hash)) {
+		return true;
+	}
+#endif
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	if (cf->load(_cfg_path()) != OK) {
+		return false;
+	}
+	r_salt = cf->get_value("password", "salt", "");
+	r_hash = cf->get_value("password", "hash", "");
+	return !r_salt.is_empty() && !r_hash.is_empty();
+}
+
+Error ScreensaverPassword::_save(const String &p_salt, const String &p_hash) {
+	if (test_override) {
+		test_salt = p_salt;
+		test_hash = p_hash;
+		return OK;
+	}
+#ifdef WINDOWS_ENABLED
+	const Error reg_err = _reg_write(p_salt, p_hash);
+	if (reg_err == OK) {
+		return OK;
+	}
+#endif
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	cf->load(_cfg_path());
+	cf->set_value("password", "salt", p_salt);
+	cf->set_value("password", "hash", p_hash);
+	return cf->save(_cfg_path());
+}
+
+Error ScreensaverPassword::_clear_store() {
+	if (test_override) {
+		test_salt = String();
+		test_hash = String();
+		return OK;
+	}
+#ifdef WINDOWS_ENABLED
+	_reg_clear_password();
+#endif
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	cf->load(_cfg_path());
+	if (cf->has_section_key("password", "salt")) {
+		cf->erase_section_key("password", "salt");
+	}
+	if (cf->has_section_key("password", "hash")) {
+		cf->erase_section_key("password", "hash");
+	}
+	return cf->save(_cfg_path());
+}
+
+bool ScreensaverPassword::_load_enabled(bool &r_enabled) {
+	if (test_override) {
+		if (!test_enabled_override) {
+			return false;
+		}
+		r_enabled = test_enabled;
+		return true;
+	}
+#ifdef WINDOWS_ENABLED
+	String raw;
+	if (_reg_read("Enabled", raw)) {
+		r_enabled = raw == "1" || raw.to_lower() == "true";
+		return true;
+	}
+#endif
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	if (cf->load(_cfg_path()) != OK) {
+		return false;
+	}
+	if (!cf->has_section_key("password", "enabled")) {
+		return false;
+	}
+	r_enabled = bool(cf->get_value("password", "enabled", false));
+	return true;
+}
+
+Error ScreensaverPassword::_save_enabled(bool p_enabled) {
+	if (test_override) {
+		test_enabled_override = true;
+		test_enabled = p_enabled;
+		return OK;
+	}
+#ifdef WINDOWS_ENABLED
+	if (_reg_write_sz("Enabled", p_enabled ? "1" : "0") == OK) {
+		return OK;
+	}
+#endif
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	cf->load(_cfg_path());
+	cf->set_value("password", "enabled", p_enabled);
+	return cf->save(_cfg_path());
+}
+
+bool ScreensaverPassword::has_password() {
+	String salt;
+	String hash;
+	return _load(salt, hash);
+}
+
+bool ScreensaverPassword::verify(const String &p_plain) {
+	String salt;
+	String hash;
+	if (!_load(salt, hash)) {
+		return false;
+	}
+	return hash_password(p_plain, salt) == hash;
+}
+
+Error ScreensaverPassword::set_password(const String &p_old_plain, const String &p_new_plain) {
+	if (has_password() && !verify(p_old_plain)) {
+		return ERR_INVALID_PARAMETER;
+	}
+	if (p_new_plain.is_empty()) {
+		return clear_password(p_old_plain);
+	}
+	const String salt = generate_salt();
+	return _save(salt, hash_password(p_new_plain, salt));
+}
+
+Error ScreensaverPassword::clear_password(const String &p_current_plain) {
+	if (has_password() && !verify(p_current_plain)) {
+		return ERR_INVALID_PARAMETER;
+	}
+	return _clear_store();
+}
+
+bool ScreensaverPassword::has_password_enabled_override() {
+	bool enabled = false;
+	return _load_enabled(enabled);
+}
+
+bool ScreensaverPassword::get_password_enabled() {
+	bool enabled = false;
+	if (_load_enabled(enabled)) {
+		return enabled;
+	}
+	return false;
+}
+
+Error ScreensaverPassword::set_password_enabled(bool p_enabled) {
+	return _save_enabled(p_enabled);
+}
+
+void ScreensaverPassword::reset_for_tests() {
+	test_override = true;
+	test_salt = String();
+	test_hash = String();
+	test_enabled_override = false;
+	test_enabled = false;
+}
+
+void ScreensaverPassword::set_store_for_tests(const String &p_salt, const String &p_hash) {
+	test_override = true;
+	test_salt = p_salt;
+	test_hash = p_hash;
+}
+
+String ScreensaverPassword::get_stored_hash_for_tests() {
+	return test_hash;
+}
+
+String ScreensaverPassword::get_stored_salt_for_tests() {
+	return test_salt;
+}
+
+void ScreensaverPassword::set_enabled_for_tests(bool p_enabled) {
+	test_override = true;
+	test_enabled_override = true;
+	test_enabled = p_enabled;
+}
+
+bool ScreensaverPassword::has_enabled_override_for_tests() {
+	return test_enabled_override;
+}
+
+bool ScreensaverPassword::get_enabled_for_tests() {
+	return test_enabled;
+}

--- a/modules/screensaver/screensaver_password.h
+++ b/modules/screensaver/screensaver_password.h
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  screensaver_password.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+
+class ScreensaverPassword {
+public:
+	static String hash_password(const String &p_plain, const String &p_salt);
+	static String generate_salt();
+	static bool has_password();
+	static bool verify(const String &p_plain);
+	static Error set_password(const String &p_old_plain, const String &p_new_plain);
+	static Error clear_password(const String &p_current_plain);
+
+	static bool has_password_enabled_override();
+	static bool get_password_enabled();
+	static Error set_password_enabled(bool p_enabled);
+
+	static String storage_key();
+
+	static void reset_for_tests();
+	static void set_store_for_tests(const String &p_salt, const String &p_hash);
+	static String get_stored_hash_for_tests();
+	static String get_stored_salt_for_tests();
+	static void set_enabled_for_tests(bool p_enabled);
+	static bool has_enabled_override_for_tests();
+	static bool get_enabled_for_tests();
+
+private:
+	static bool _load(String &r_salt, String &r_hash);
+	static Error _save(const String &p_salt, const String &p_hash);
+	static Error _clear_store();
+	static bool _load_enabled(bool &r_enabled);
+	static Error _save_enabled(bool p_enabled);
+
+	static bool test_override;
+	static String test_salt;
+	static String test_hash;
+	static bool test_enabled_override;
+	static bool test_enabled;
+};

--- a/modules/screensaver/tests/test_screensaver.cpp
+++ b/modules/screensaver/tests/test_screensaver.cpp
@@ -1,0 +1,31 @@
+/**************************************************************************/
+/*  test_screensaver.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_screensaver_cmdline.h"
+#include "test_screensaver_password.h"

--- a/modules/screensaver/tests/test_screensaver_cmdline.h
+++ b/modules/screensaver/tests/test_screensaver_cmdline.h
@@ -1,0 +1,714 @@
+/**************************************************************************/
+/*  test_screensaver_cmdline.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/config/project_settings.h"
+#include "core/math/rect2i.h"
+#include "core/os/os.h"
+#include "modules/screensaver/screensaver.h"
+#include "modules/screensaver/screensaver_cmdline.h"
+#include "tests/test_macros.h"
+
+static void _apply_screensaver(DisplayServer::WindowMode &r_window_mode, uint32_t &r_flags, int64_t &r_embed, Vector2i &r_pos, Size2i &r_size, int &r_screen, bool &r_use_pos) {
+	ScreensaverCmdline::apply_recorded(r_window_mode, r_flags, r_embed, r_pos, r_size, r_screen, r_use_pos);
+}
+
+TEST_CASE("[Modules][Screensaver] consume /s") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "2", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::resolved_target_screen() == 2);
+}
+
+TEST_CASE("[Modules][Screensaver] cover_os_rect fills the monitor") {
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_monitor_rect_for_tests(1, Rect2i(1920, 0, 1920, 1080));
+	const Rect2i cover = ScreensaverCmdline::cover_os_rect(1);
+	CHECK(cover.position == Vector2i(1920, 0));
+	CHECK(cover.size == Size2i(1920, 1080));
+	ScreensaverCmdline::clear_monitor_rect_for_tests();
+}
+
+TEST_CASE("[Modules][Screensaver] normalize_screen_index") {
+	CHECK(ScreensaverCmdline::normalize_screen_index(0, 3) == 0);
+	CHECK(ScreensaverCmdline::normalize_screen_index(1, 3) == 1);
+	CHECK(ScreensaverCmdline::normalize_screen_index(2, 3) == 2);
+	CHECK(ScreensaverCmdline::normalize_screen_index(3, 3) == 2);
+	CHECK(ScreensaverCmdline::normalize_screen_index(4, 3) == -1);
+	CHECK(ScreensaverCmdline::normalize_screen_index(-1, 3) == -1);
+}
+
+TEST_CASE("[Modules][Screensaver] order_monitor_rects primary first then left-to-right") {
+	Vector<Rect2i> raw;
+	raw.push_back(Rect2i(-1920, 0, 1920, 1080));
+	raw.push_back(Rect2i(-3840, 0, 1920, 1080));
+	raw.push_back(Rect2i(0, 0, 1920, 1080));
+	const Vector<Rect2i> ordered = ScreensaverCmdline::order_monitor_rects(raw, 2);
+	REQUIRE(ordered.size() == 3);
+	CHECK(ordered[0] == Rect2i(0, 0, 1920, 1080));
+	CHECK(ordered[1] == Rect2i(-3840, 0, 1920, 1080));
+	CHECK(ordered[2] == Rect2i(-1920, 0, 1920, 1080));
+}
+
+TEST_CASE("[Modules][Screensaver] host /S launch spans all monitors") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+	ps->set_setting("blazium/screensaver/cover_mode", "single");
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_host_screensaver_launch_for_tests(true);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "virtual");
+
+	ScreensaverCmdline::set_target_screen(1);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_host_screensaver_launch_for_tests();
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}
+
+TEST_CASE("[Modules][Screensaver] ingest BLAZIUM_SCREENSAVER env when cmdline has no --screen") {
+	REQUIRE(OS::get_singleton() != nullptr);
+	const String prev_screen = OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_SCREEN");
+	const String prev_cover = OS::get_singleton()->get_environment("BLAZIUM_SCREENSAVER_COVER");
+
+	ScreensaverCmdline::reset();
+	OS::get_singleton()->set_environment("BLAZIUM_SCREENSAVER_SCREEN", "2");
+	OS::get_singleton()->unset_environment("BLAZIUM_SCREENSAVER_COVER");
+	ScreensaverCmdline::ingest_from_os_command_line();
+	CHECK(ScreensaverCmdline::get_target_screen_override() == 2);
+
+	ScreensaverCmdline::reset();
+	OS::get_singleton()->unset_environment("BLAZIUM_SCREENSAVER_SCREEN");
+	OS::get_singleton()->set_environment("BLAZIUM_SCREENSAVER_COVER", "virtual");
+	ScreensaverCmdline::ingest_from_os_command_line();
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "virtual");
+
+	ScreensaverCmdline::reset();
+	if (prev_screen.is_empty()) {
+		OS::get_singleton()->unset_environment("BLAZIUM_SCREENSAVER_SCREEN");
+	} else {
+		OS::get_singleton()->set_environment("BLAZIUM_SCREENSAVER_SCREEN", prev_screen);
+	}
+	if (prev_cover.is_empty()) {
+		OS::get_singleton()->unset_environment("BLAZIUM_SCREENSAVER_COVER");
+	} else {
+		OS::get_singleton()->set_environment("BLAZIUM_SCREENSAVER_COVER", prev_cover);
+	}
+}
+
+TEST_CASE("[Modules][Screensaver] os_monitor_count override") {
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_os_monitor_count_for_tests(3);
+	CHECK(ScreensaverCmdline::os_monitor_count() == 3);
+	CHECK(ScreensaverCmdline::normalize_screen_index(0, ScreensaverCmdline::os_monitor_count()) == 0);
+	CHECK(ScreensaverCmdline::normalize_screen_index(2, ScreensaverCmdline::os_monitor_count()) == 2);
+	CHECK(ScreensaverCmdline::normalize_screen_index(3, ScreensaverCmdline::os_monitor_count()) == 2);
+	ScreensaverCmdline::clear_os_monitor_count_for_tests();
+	CHECK(ScreensaverCmdline::os_monitor_count() >= 1);
+}
+
+TEST_CASE("[Modules][Screensaver] consume /s:N") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s:2", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::resolved_target_screen() == 2);
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/s:0", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::resolved_target_screen() == 0);
+}
+
+TEST_CASE("[Modules][Screensaver] consume --screensaver-cover") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("--screensaver-cover", "virtual", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "virtual");
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("--screensaver-cover", "clone", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "clone");
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("--screensaver-cover", "single", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+}
+
+TEST_CASE("[Modules][Screensaver] consume /p hwnd") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/p", "1234", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_PREVIEW);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 1234);
+}
+
+TEST_CASE("[Modules][Screensaver] consume /c and /c:hwnd and /C") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/c", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/c:1234", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 1234);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/c", "1234", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 1234);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/c1234", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 1234);
+	CHECK(ScreensaverCmdline::get_target_screen_override() < 0);
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/C", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/c:0", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 0);
+	CHECK(ScreensaverCmdline::get_mode() != ScreensaverCmdline::MODE_RUN);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/c", "not-a-hwnd", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 0);
+	CHECK(ScreensaverCmdline::get_mode() != ScreensaverCmdline::MODE_RUN);
+}
+
+TEST_CASE("[Modules][Screensaver] /s HWND and bare HWND are preview; /s N stays screen") {
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_hwnd_valid_for_tests();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "2", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::resolved_target_screen() == 2);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "123456", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::get_target_screen_override() < 0);
+	CHECK(ScreensaverCmdline::get_mode() != ScreensaverCmdline::MODE_PREVIEW);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_hwnd_valid_for_tests(123456);
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "123456", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_PREVIEW);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 123456);
+	CHECK(ScreensaverCmdline::get_target_screen_override() < 0);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_hwnd_valid_for_tests(123456);
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("123456", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_PREVIEW);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 123456);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_hwnd_valid_for_tests();
+}
+
+TEST_CASE("[Modules][Screensaver] rundll32 is not idle host; explorer /s still virtual") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+	ps->set_setting("blazium/screensaver/cover_mode", "single");
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_host_screensaver_launch_for_tests(false);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_hwnd_valid_for_tests(123456);
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "123456", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_PREVIEW);
+	CHECK_FALSE(ScreensaverCmdline::is_host_screensaver_launch());
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_hwnd_valid_for_tests();
+	ScreensaverCmdline::set_host_screensaver_launch_for_tests(true);
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "virtual");
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_host_screensaver_launch_for_tests();
+	ScreensaverCmdline::clear_hwnd_valid_for_tests();
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}
+
+TEST_CASE("[Modules][Screensaver] consume /a hwnd and /A") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/a", "1234", consumed_next));
+	CHECK(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CHANGE_PASSWORD);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 1234);
+
+	ScreensaverCmdline::reset();
+	consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/A", "99", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CHANGE_PASSWORD);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 99);
+}
+
+TEST_CASE("[Modules][Screensaver] consume hex HWND and colon /p /a") {
+	ScreensaverCmdline::reset();
+	int64_t hwnd = 0;
+	CHECK(ScreensaverCmdline::parse_hwnd_token("0x1A2B", hwnd));
+	CHECK(hwnd == 0x1A2B);
+	CHECK(ScreensaverCmdline::parse_hwnd_token("0X10", hwnd));
+	CHECK(hwnd == 0x10);
+	CHECK_FALSE(ScreensaverCmdline::parse_hwnd_token("", hwnd));
+	CHECK_FALSE(ScreensaverCmdline::parse_hwnd_token("not-a-hwnd", hwnd));
+
+	bool consumed_next = false;
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/p:4321", "", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_PREVIEW);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 4321);
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/a:0x20", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CHANGE_PASSWORD);
+	CHECK(ScreensaverCmdline::get_parent_hwnd() == 0x20);
+}
+
+TEST_CASE("[Modules][Screensaver] ignore Godot -s --script --screen and -p") {
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK_FALSE(ScreensaverCmdline::try_consume("-s", "res://x.gd", consumed_next));
+	CHECK_FALSE(ScreensaverCmdline::try_consume("--script", "res://x.gd", consumed_next));
+	CHECK_FALSE(ScreensaverCmdline::try_consume("--screen", "1", consumed_next));
+	CHECK_FALSE(consumed_next);
+	CHECK_FALSE(ScreensaverCmdline::try_consume("-p", "", consumed_next));
+	CHECK_FALSE(ScreensaverCmdline::try_consume("--project-manager", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_NONE);
+}
+
+TEST_CASE("[Modules][Screensaver] apply_recorded modes and enabled gate") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const bool prev_cover = bool(ps->get_setting("blazium/screensaver/cover_all_screens", true));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+	const int prev_screen = int(ps->get_setting("blazium/screensaver/screen", -1));
+
+	ps->set_setting("blazium/screensaver/enabled", false);
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_virtual_rect_for_tests();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	uint32_t flags = 0;
+	int64_t embed = 99;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(embed == 99);
+	CHECK_FALSE(use_pos);
+
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", String());
+	ps->set_setting("blazium/screensaver/cover_all_screens", false);
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	flags = 0;
+	embed = 7;
+	screen = DisplayServer::SCREEN_PRIMARY;
+	use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK(embed == 0);
+	CHECK_FALSE(use_pos);
+	CHECK(ScreensaverCmdline::should_clear_create_position());
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/p", "1234", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = 0;
+	embed = 0;
+	pos = Vector2i(640, 360);
+	size = Size2i(1920, 1080);
+	use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK(embed == 1234);
+	CHECK(use_pos);
+	CHECK(pos == Vector2i());
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/c", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+	embed = 5;
+	size = Size2i(1920, 1080);
+	use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) == 0);
+	CHECK(embed == 0);
+	CHECK(size == Size2i(480, 320));
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/c:1234", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+	embed = 9;
+	size = Size2i(1920, 1080);
+	use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) == 0);
+	CHECK(embed == 0);
+	CHECK(size == Size2i(480, 320));
+
+	ScreensaverCmdline::reset();
+	CHECK(ScreensaverCmdline::try_consume("/a", "88", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+	embed = 88;
+	size = Size2i(1920, 1080);
+	use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) == 0);
+	CHECK(embed == 0);
+	CHECK(size == Size2i(480, 320));
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_virtual_rect_for_tests();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_all_screens", prev_cover);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+	ps->set_setting("blazium/screensaver/screen", prev_screen);
+}
+
+TEST_CASE("[Modules][Screensaver] flagless .scr defaults to configure not run") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	ps->set_setting("blazium/screensaver/enabled", true);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_executable_is_scr_for_tests(true);
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+	int64_t embed = 9;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_CONFIGURE);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) == 0);
+	CHECK(embed == 0);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_executable_is_scr_for_tests(true);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	flags = 0;
+	embed = 3;
+	use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK(embed == 0);
+
+	ScreensaverCmdline::clear_executable_is_scr_for_tests();
+	ScreensaverCmdline::reset();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+}
+
+TEST_CASE("[Modules][Screensaver] cover_mode virtual records windowed run without create rect") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const bool prev_cover = bool(ps->get_setting("blazium/screensaver/cover_all_screens", true));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+
+	const Rect2i virt(-1920, 0, 5760, 1080);
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_virtual_rect_for_tests(virt);
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", "virtual");
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = 0;
+	int64_t embed = 7;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_BORDERLESS_BIT) != 0);
+	CHECK((flags & DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT) != 0);
+	CHECK_FALSE(use_pos);
+	CHECK(ScreensaverCmdline::should_clear_create_position());
+	CHECK(ScreensaverCmdline::virtual_os_rect().size == Size2i(5760, 1080));
+	CHECK(embed == 0);
+
+	ps->set_setting("blazium/screensaver/cover_mode", String());
+	ps->set_setting("blazium/screensaver/cover_all_screens", true);
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_virtual_rect_for_tests(virt);
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	flags = 0;
+	screen = DisplayServer::SCREEN_PRIMARY;
+	use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK_FALSE(use_pos);
+	CHECK(ScreensaverCmdline::should_clear_create_position());
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_virtual_rect_for_tests();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_all_screens", prev_cover);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}
+
+TEST_CASE("[Modules][Screensaver] cover_mode single honors screen index") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+	const int prev_screen = int(ps->get_setting("blazium/screensaver/screen", -1));
+
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", "single");
+	ps->set_setting("blazium/screensaver/screen", -1);
+	const Rect2i mon2(1920, 0, 1920, 1080);
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_monitor_rect_for_tests(2, mon2);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s:2", "", consumed_next));
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = 0;
+	int64_t embed = 7;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_FULLSCREEN);
+	CHECK(screen == 2);
+	CHECK_FALSE(use_pos);
+	CHECK(embed == 0);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_monitor_rect_for_tests(1, Rect2i(0, 0, 1280, 1024));
+	ps->set_setting("blazium/screensaver/screen", 1);
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	screen = DisplayServer::SCREEN_PRIMARY;
+	use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(screen == 1);
+	CHECK_FALSE(use_pos);
+
+	ScreensaverCmdline::clear_monitor_rect_for_tests();
+
+	ScreensaverCmdline::reset();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+	ps->set_setting("blazium/screensaver/screen", prev_screen);
+}
+
+TEST_CASE("[Modules][Screensaver] cover_mode clone records run without spawning") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", "clone");
+	ScreensaverCmdline::reset();
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK(ScreensaverCmdline::get_mode() == ScreensaverCmdline::MODE_RUN);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "clone");
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+	uint32_t flags = 0;
+	int64_t embed = 7;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = true;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK_FALSE(use_pos);
+
+	CHECK_FALSE(ScreensaverCmdline::should_spawn_clone_windows());
+	if (Screensaver::get_singleton()) {
+		CHECK(Screensaver::get_singleton()->get_mode() == Screensaver::MODE_RUN);
+	}
+
+	ScreensaverCmdline::reset();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}
+
+TEST_CASE("[Modules][Screensaver] Main --screen notify overrides virtual cover") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+
+	const Rect2i mon2(1920, 0, 1920, 1080);
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", "virtual");
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_target_screen(2);
+	ScreensaverCmdline::set_monitor_rect_for_tests(2, mon2);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = 0;
+	int64_t embed = 7;
+	Vector2i pos;
+	Size2i size;
+	int screen = DisplayServer::SCREEN_PRIMARY;
+	bool use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_FULLSCREEN);
+	CHECK(screen == 2);
+	CHECK_FALSE(use_pos);
+	CHECK(ScreensaverCmdline::should_clear_create_position());
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_monitor_rect_for_tests();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}
+
+TEST_CASE("[Modules][Screensaver] --screen N overrides virtual cover") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	REQUIRE(ps != nullptr);
+	const bool prev_enabled = bool(ps->get_setting("blazium/screensaver/enabled", false));
+	const String prev_cover_mode = ps->get_setting("blazium/screensaver/cover_mode", String());
+
+	const Rect2i mon2(1920, 0, 1920, 1080);
+	ps->set_setting("blazium/screensaver/enabled", true);
+	ps->set_setting("blazium/screensaver/cover_mode", "virtual");
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::set_monitor_rect_for_tests(2, mon2);
+	bool consumed_next = false;
+	CHECK(ScreensaverCmdline::try_consume("/s", "", consumed_next));
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+	uint32_t flags = 0;
+	int64_t embed = 7;
+	Vector2i pos;
+	Size2i size;
+	int screen = 2;
+	bool use_pos = false;
+	_apply_screensaver(window_mode, flags, embed, pos, size, screen, use_pos);
+	CHECK(ScreensaverCmdline::resolved_cover_mode() == "single");
+	CHECK(window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_FULLSCREEN);
+	CHECK(window_mode != DisplayServer::WINDOW_MODE_EXCLUSIVE_FULLSCREEN);
+	CHECK(screen == 2);
+	CHECK_FALSE(use_pos);
+
+	ScreensaverCmdline::reset();
+	ScreensaverCmdline::clear_monitor_rect_for_tests();
+	ps->set_setting("blazium/screensaver/enabled", prev_enabled);
+	ps->set_setting("blazium/screensaver/cover_mode", prev_cover_mode);
+}

--- a/modules/screensaver/tests/test_screensaver_password.h
+++ b/modules/screensaver/tests/test_screensaver_password.h
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  test_screensaver_password.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/screensaver/screensaver_password.h"
+#include "tests/test_macros.h"
+
+TEST_CASE("[Modules][Screensaver] hash verify set clear") {
+	ScreensaverPassword::reset_for_tests();
+	CHECK_FALSE(ScreensaverPassword::has_password());
+
+	const String salt = ScreensaverPassword::generate_salt();
+	const String hash = ScreensaverPassword::hash_password("secret", salt);
+	CHECK_FALSE(hash.is_empty());
+	CHECK(hash != "secret");
+	CHECK(ScreensaverPassword::hash_password("secret", salt) == hash);
+	CHECK(ScreensaverPassword::hash_password("other", salt) != hash);
+
+	CHECK(ScreensaverPassword::set_password("", "secret") == OK);
+	CHECK(ScreensaverPassword::has_password());
+	CHECK(ScreensaverPassword::verify("secret"));
+	CHECK_FALSE(ScreensaverPassword::verify("wrong"));
+	CHECK_FALSE(ScreensaverPassword::get_stored_hash_for_tests().contains("secret"));
+	CHECK_FALSE(ScreensaverPassword::get_stored_salt_for_tests().contains("secret"));
+
+	CHECK(ScreensaverPassword::set_password("wrong", "next") == ERR_INVALID_PARAMETER);
+	CHECK(ScreensaverPassword::verify("secret"));
+
+	CHECK(ScreensaverPassword::set_password("secret", "next") == OK);
+	CHECK(ScreensaverPassword::verify("next"));
+
+	CHECK(ScreensaverPassword::clear_password("wrong") == ERR_INVALID_PARAMETER);
+	CHECK(ScreensaverPassword::clear_password("next") == OK);
+	CHECK_FALSE(ScreensaverPassword::has_password());
+}
+
+TEST_CASE("[Modules][Screensaver] password_enabled persist in test store") {
+	ScreensaverPassword::reset_for_tests();
+	CHECK_FALSE(ScreensaverPassword::has_password_enabled_override());
+	CHECK_FALSE(ScreensaverPassword::has_enabled_override_for_tests());
+
+	CHECK(ScreensaverPassword::set_password_enabled(true) == OK);
+	CHECK(ScreensaverPassword::has_password_enabled_override());
+	CHECK(ScreensaverPassword::get_password_enabled());
+	CHECK(ScreensaverPassword::get_enabled_for_tests());
+
+	CHECK(ScreensaverPassword::set_password_enabled(false) == OK);
+	CHECK(ScreensaverPassword::has_password_enabled_override());
+	CHECK_FALSE(ScreensaverPassword::get_password_enabled());
+	CHECK_FALSE(ScreensaverPassword::get_enabled_for_tests());
+
+	ScreensaverPassword::set_enabled_for_tests(true);
+	CHECK(ScreensaverPassword::get_password_enabled());
+
+	CHECK(ScreensaverPassword::set_password("", "secret") == OK);
+	CHECK(ScreensaverPassword::has_password());
+	CHECK(ScreensaverPassword::get_password_enabled());
+	CHECK(ScreensaverPassword::clear_password("secret") == OK);
+	CHECK_FALSE(ScreensaverPassword::has_password());
+	CHECK(ScreensaverPassword::has_password_enabled_override());
+	CHECK(ScreensaverPassword::get_password_enabled());
+}


### PR DESCRIPTION
## Summary
- Add the `screensaver` module that honors Control Panel `/s` `/p` `/c` `/a` switches, cover modes, and password unlock.
- Windows editor and `screensaver_template` builds only. Exports `.scr`.

## Test plan
- [ ] Build `platform=windows target=editor tests=yes`
- [ ] Run `--headless --test --test-case=*[Screensaver]*`
- [ ] Confirm Linux/macOS/Android editors skip the module