### PR TITLE
JustAMCP: opt-in host, game port +1, project-owned tools

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -672,11 +672,14 @@
 		</member>
 		<member name="blazium/justamcp/enable_toolset_discovery" type="bool" setter="" getter="" default="true">
 		</member>
+		<member name="blazium/justamcp/export_port" type="int" setter="" getter="" default="0">
+			TCP port for the exported or play-mode JustAMCP HTTP MCP host ([code]POST /mcp[/code]). [code]0[/code] means the editor [member blazium/justamcp/server_port] plus one (6506 → 6507). Override at launch with [code]--mcp-game-port[/code]. Must not equal the editor port. [code]remote_control[/code] also defaults to 6507; if bind fails the host retries once on port+1.
+		</member>
 		<member name="blazium/justamcp/forward_engine_logs" type="bool" setter="" getter="" default="true">
 			If [code]true[/code] and the JustAMCP server is running, engine [code]print[/code] output is forwarded to MCP clients via [code]notifications/message[/code] ([code]logger: engine[/code]). Respects the client's [code]logging/setLevel[/code] minimum severity.
 		</member>
 		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
+			If [code]true[/code], starts the game JustAMCP host (Streamable HTTP on the export port plus the TCP command bridge). Autowork [code]--aw-*[/code] does not start MCP unless [code]--enable-mcp[/code] or [code]--enable-mcp-game-control[/code] is also passed. Exported templates include the HTTP host only; editor tools are not compiled in.
 		</member>
 		<member name="blazium/justamcp/in_flight_cancel_deadline_ms" type="int" setter="" getter="" default="5000">
 		</member>
@@ -713,6 +716,9 @@
 		<member name="blazium/justamcp/parallel_readonly_lane" type="bool" setter="" getter="" default="false">
 		</member>
 		<member name="blazium/justamcp/pending_post_sse_timeout_sec" type="int" setter="" getter="" default="120">
+		</member>
+		<member name="blazium/justamcp/project_mcp_dir" type="String" setter="" getter="" default="&quot;res://mcp&quot;">
+			Folder that holds project-owned MCP registration scripts. When game MCP starts, JustAMCP runs [code]register.gd[/code] and/or [code]register.luau[/code] from this directory so they can call [method JustAMCPRuntime.register_tool] and [method JustAMCPRuntime.register_prompt].
 		</member>
 		<member name="blazium/justamcp/prompts" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], JustAMCP includes prompts in [code]prompts/list[/code]. Individual prompt toggles under [code]blazium/justamcp/prompts/[/code] still apply. Search and get still reach unlisted prompts.
@@ -900,10 +906,10 @@
 			Read-only MCP resource metadata for [code]Video Recordings Cache[/code]. Description: Returns an index of all sequential video snapshot frames captured by the runtime recording hook.
 		</member>
 		<member name="blazium/justamcp/server_enabled" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], starts the JustAMCP Model Context Protocol (MCP) HTTP server when the editor loads. Also enabled by the [code]--enable-mcp[/code] command-line flag.
+			If [code]true[/code], starts the editor JustAMCP MCP HTTP server when the editor loads. Also enabled by [code]--enable-mcp[/code]. Autowork [code]--aw-*[/code], [code]--test[/code], and [code]--export*[/code] skip MCP unless [code]--enable-mcp[/code] or [code]--enable-mcp-game-control[/code] is also on the command line. The server is not constructed when this is [code]false[/code].
 		</member>
 		<member name="blazium/justamcp/server_port" type="int" setter="" getter="" default="6506">
-			TCP port for the JustAMCP MCP HTTP endpoint ([code]POST /mcp[/code]). Override at launch with [code]--mcp-port[/code].
+			TCP port for the editor JustAMCP MCP HTTP endpoint ([code]POST /mcp[/code]). Override at launch with [code]--mcp-port[/code]. The game host uses [member blazium/justamcp/export_port] or this value plus one, never this port.
 		</member>
 		<member name="blazium/justamcp/session_allow_client_delete" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], MCP clients may terminate a Streamable HTTP session with [code]DELETE /mcp[/code] and the [code]MCP-Session-Id[/code] header.

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -93,6 +93,9 @@ for name, path in env.module_list.items():
         import glob
 
         module_tests = sorted(glob.glob(os.path.join(base_path, "tests", "*.h")))
+        if name == "justamcp" and not env.editor_build:
+            # Editor-only JustAMCP suites require TOOLS_ENABLED implementations.
+            module_tests = []
         if module_tests != []:
             test_headers += module_tests
 

--- a/modules/justamcp/SCsub
+++ b/modules/justamcp/SCsub
@@ -32,18 +32,65 @@ host_html_header = env_justamcp.Command(
     env.Run(make_justamcp_host_html),
 )
 
-# Blazium source files
-env_justamcp.add_source_files(env.modules_sources, "*.cpp")
-env_justamcp.add_source_files(env.modules_sources, "tools/*.cpp")
-env_justamcp.add_source_files(env.modules_sources, "tools/prompts/*.cpp")
-env_justamcp.add_source_files(env.modules_sources, "tools/resources/*.cpp")
-env.Depends(env.modules_sources, host_html_header)
+if env.editor_build:
+    env_justamcp.add_source_files(env.modules_sources, "*.cpp")
+    env_justamcp.add_source_files(env.modules_sources, "tools/*.cpp")
+    env_justamcp.add_source_files(env.modules_sources, "tools/prompts/*.cpp")
+    env_justamcp.add_source_files(env.modules_sources, "tools/resources/*.cpp")
+    env.Depends(env.modules_sources, host_html_header)
+else:
+    # Export templates: Streamable HTTP host + registration API only.
+    env_justamcp.add_source_files(
+        env.modules_sources,
+        [
+            "justamcp_cli_args.cpp",
+            "justamcp_event_store.cpp",
+            "justamcp_json_rpc_list.cpp",
+            "justamcp_json_rpc_transport.cpp",
+            "justamcp_log_levels.cpp",
+            "justamcp_mcp_spec.cpp",
+            "justamcp_notification_bus.cpp",
+            "justamcp_oauth_discovery.cpp",
+            "justamcp_pagination.cpp",
+            "justamcp_project_registry.cpp",
+            "justamcp_request_router.cpp",
+            "justamcp_runtime.cpp",
+            "justamcp_runtime_commands.cpp",
+            "justamcp_runtime_input.cpp",
+            "justamcp_runtime_query_eval.cpp",
+            "justamcp_runtime_query_serialize.cpp",
+            "justamcp_runtime_query_tree.cpp",
+            "justamcp_runtime_query_ui.cpp",
+            "justamcp_runtime_tcp.cpp",
+            "justamcp_server.cpp",
+            "justamcp_server_http.cpp",
+            "justamcp_server_notifications.cpp",
+            "justamcp_server_request_lookup.cpp",
+            "justamcp_server_results.cpp",
+            "justamcp_server_tool_lifecycle.cpp",
+            "justamcp_server_tool_queue.cpp",
+            "justamcp_session_manager.cpp",
+            "justamcp_session_manager_core.cpp",
+            "justamcp_session_manager_http_delete.cpp",
+            "justamcp_session_manager_http_get.cpp",
+            "justamcp_session_manager_http_post.cpp",
+            "justamcp_tool_context.cpp",
+            "justamcp_tool_dispatch.cpp",
+            "justamcp_tool_queue_state.cpp",
+            "mcp_tool_queue.cpp",
+            "register_types.cpp",
+            "tools/justamcp_json_rpc_helpers.cpp",
+            "tools/justamcp_readonly_tools.cpp",
+            "tools/justamcp_settings_resolver.cpp",
+        ],
+    )
 
 if env["tests"]:
     env_justamcp.Append(CPPDEFINES=["TESTS_ENABLED"])
-    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_elicitation.cpp")
-    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_oauth_discovery.cpp")
-    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_protocol_matrix.cpp")
+    if env.editor_build:
+        env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_elicitation.cpp")
+        env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_oauth_discovery.cpp")
+        env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_protocol_matrix.cpp")
 
     if env["disable_exceptions"]:
         env_justamcp.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/justamcp/config.py
+++ b/modules/justamcp/config.py
@@ -2,10 +2,11 @@ def can_build(env, platform):
     # Depending on websocket and mbedtls for networking
     env.module_add_dependencies("justamcp", ["websocket", "mbedtls"], True)
     env.module_add_dependencies("justamcp", ["httpserver"], False)
-    env.module_add_dependencies("justamcp", ["assettags"], False)
-    env.module_add_dependencies("justamcp", ["semanticsearch"], False)
-    env.module_add_dependencies("justamcp", ["remote_control"], False)
-    return env.editor_build
+    # Editor-only modules: required in the editor catalog, optional in export templates.
+    env.module_add_dependencies("justamcp", ["assettags"], True)
+    env.module_add_dependencies("justamcp", ["semanticsearch"], True)
+    env.module_add_dependencies("justamcp", ["remote_control"], True)
+    return True
 
 
 def configure(env):

--- a/modules/justamcp/doc_classes/JustAMCPRuntime.xml
+++ b/modules/justamcp/doc_classes/JustAMCPRuntime.xml
@@ -4,20 +4,19 @@
 		Engine singleton that hosts the JustAMCP runtime server.
 	</brief_description>
 	<description>
-		[JustAMCPRuntime] runs the local MCP endpoint and routes incoming commands to built-in tools, resources, prompts, or custom command callables. It is independent of the active [SceneTree], so it can keep serving editor automation while scenes are opened, closed, or changed.
+		[JustAMCPRuntime] hosts the exported or play-mode MCP endpoint. The HTTP host exposes only project-owned tools and prompts registered with [method register_tool] and [method register_prompt]. The TCP bridge still accepts [method register_custom_command]. It is independent of the active [SceneTree], so it can keep serving while scenes are opened, closed, or changed.
+		The game HTTP MCP host listens on [member ProjectSettings.blazium/justamcp/export_port] when set, otherwise the editor port plus one (6506 → 6507). Autowork [code]--aw-*[/code] does not start MCP unless [code]--enable-mcp[/code] or [code]--enable-mcp-game-control[/code] is also passed. Project-owned Cursor tools register through [method register_tool]; TCP [method register_custom_command] stays for the game-control bridge.
 		[codeblock]
-		JustAMCPRuntime.port = 6506
+		JustAMCPRuntime.port = 6507
 		JustAMCPRuntime.enabled = true
+
+		JustAMCPRuntime.register_tool("echo", "Echo text", {"type": "object", "properties": {"text": {"type": "string"}}}, func(args):
+		    return args.get("text", "")
+		)
 
 		JustAMCPRuntime.register_custom_command("double", func(value):
 		    return value * 2
 		)
-
-		var result = JustAMCPRuntime.execute_command("run_custom_command", {
-		    "name": "double",
-		    "args": [21],
-		})
-		print(result["result"])
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -29,6 +28,24 @@
 			<param index="1" name="params" type="Dictionary" />
 			<description>
 				Executes a runtime command with [param params] and returns the command result dictionary. Commands include built-in runtime operations, tool dispatch, resources, prompts, and [code]run_custom_command[/code].
+			</description>
+		</method>
+		<method name="is_listening" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the HTTP MCP host or TCP game-control bridge is accepting connections.
+			</description>
+		</method>
+		<method name="list_tools" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns schemas for project-owned tools registered with [method register_tool].
+			</description>
+		</method>
+		<method name="load_project_mcp_scripts">
+			<return type="void" />
+			<description>
+				Loads [code]register.gd[/code] and [code]register.luau[/code] from [member ProjectSettings.blazium/justamcp/project_mcp_dir] (default [code]res://mcp[/code]) so those scripts can call [method register_tool] and [method register_prompt].
 			</description>
 		</method>
 		<method name="poll">
@@ -45,6 +62,25 @@
 				Registers [param callable] under [param name] so MCP clients can invoke it with [code]execute_command("run_custom_command", {"name": name, "args": [...]})[/code]. Registering the same name replaces the previous callable.
 			</description>
 		</method>
+		<method name="register_prompt">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="description" type="String" />
+			<param index="2" name="callable" type="Callable" />
+			<description>
+				Registers a project-owned MCP prompt. [param callable] receives the prompt argument dictionary and should return messages or a string. Same ClassDB API for GDScript and Luau.
+			</description>
+		</method>
+		<method name="register_tool">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="description" type="String" />
+			<param index="2" name="input_schema" type="Dictionary" />
+			<param index="3" name="callable" type="Callable" />
+			<description>
+				Registers a project-owned Streamable HTTP MCP tool that appears in [code]tools/list[/code] and is invoked by [code]tools/call[/code]. [param input_schema] is a JSON Schema object. Same ClassDB API for GDScript and Luau.
+			</description>
+		</method>
 		<method name="unregister_custom_command">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
@@ -52,13 +88,27 @@
 				Removes the custom command registered as [param name]. Calls to [code]run_custom_command[/code] with that name will return an error after removal.
 			</description>
 		</method>
+		<method name="unregister_prompt">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Removes the project-owned MCP prompt registered as [param name].
+			</description>
+		</method>
+		<method name="unregister_tool">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Removes the project-owned MCP tool registered as [param name].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="false">
 			When [code]true[/code], the runtime server is active and can accept MCP traffic. Setting it to [code]false[/code] stops serving runtime requests.
 		</member>
-		<member name="port" type="int" setter="set_port" getter="get_port" default="6506">
-			TCP port used by the JustAMCP runtime server. Defaults to the same [code]6506[/code] as the editor HTTP server. Override at launch with [code]--mcp-port[/code], or change this before enabling the runtime.
+		<member name="port" type="int" setter="set_port" getter="get_port" default="6507">
+			Game MCP port. Defaults to the editor HTTP port plus one (6506 → 6507). Override with [code]--mcp-game-port[/code] or [member ProjectSettings.blazium/justamcp/export_port]. Never bind the editor port. [code]remote_control[/code] also defaults to 6507; if bind fails the host retries once on port+1.
 		</member>
 	</members>
 	<signals>

--- a/modules/justamcp/justamcp_cli_args.cpp
+++ b/modules/justamcp/justamcp_cli_args.cpp
@@ -11,10 +11,12 @@
 #include "core/os/os.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
+#include "core/templates/vector.h"
 #include "servers/display_server.h"
 
 #ifdef TESTS_ENABLED
 static int _test_mcp_port = -1;
+static int _test_mcp_game_port = -1;
 #endif
 
 static bool _justamcp_has_arg(const String &p_arg) {
@@ -26,9 +28,13 @@ static bool _justamcp_has_arg(const String &p_arg) {
 	return false;
 }
 
+bool JustAMCPCliArgs::is_valid_port(int p_port) {
+	return p_port >= 1 && p_port <= 65535;
+}
+
 int JustAMCPCliArgs::mcp_port() {
 #ifdef TESTS_ENABLED
-	if (_test_mcp_port > 0) {
+	if (is_valid_port(_test_mcp_port)) {
 		return _test_mcp_port;
 	}
 #endif
@@ -36,7 +42,25 @@ int JustAMCPCliArgs::mcp_port() {
 	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
 		if (E->get() == "--mcp-port" && E->next()) {
 			const int port = E->next()->get().to_int();
-			if (port > 0) {
+			if (is_valid_port(port)) {
+				return port;
+			}
+		}
+	}
+	return -1;
+}
+
+int JustAMCPCliArgs::mcp_game_port() {
+#ifdef TESTS_ENABLED
+	if (is_valid_port(_test_mcp_game_port)) {
+		return _test_mcp_game_port;
+	}
+#endif
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+		if (E->get() == "--mcp-game-port" && E->next()) {
+			const int port = E->next()->get().to_int();
+			if (is_valid_port(port)) {
 				return port;
 			}
 		}
@@ -67,15 +91,37 @@ bool JustAMCPCliArgs::is_unit_test() {
 	return _justamcp_has_arg("--test") || _justamcp_has_arg("--tests");
 }
 
-bool JustAMCPCliArgs::skip_mcp_server() {
-	for (const String &arg : OS::get_singleton()->get_cmdline_args()) {
+bool JustAMCPCliArgs::skip_mcp_server_for_args(const Vector<String> &p_args) {
+	bool skip = false;
+	bool enable = false;
+	for (int i = 0; i < p_args.size(); i++) {
+		const String &arg = p_args[i];
 		if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
 				arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
 				arg == "--check-only" || arg.begins_with("--export")) {
-			return true;
+			skip = true;
+		}
+		if (arg == "--enable-mcp" || arg == "--enable-mcp-game-control") {
+			enable = true;
 		}
 	}
-	return false;
+	return skip && !enable;
+}
+
+bool JustAMCPCliArgs::skip_mcp_server() {
+	Vector<String> args;
+	for (const String &arg : OS::get_singleton()->get_cmdline_args()) {
+		args.push_back(arg);
+	}
+	return skip_mcp_server_for_args(args);
+}
+
+bool JustAMCPCliArgs::should_instantiate_editor_server_for(bool p_skip, bool p_server_enabled) {
+	return !p_skip && p_server_enabled;
+}
+
+bool JustAMCPCliArgs::should_instantiate_runtime_for(bool p_skip, bool p_game_requested) {
+	return !p_skip && p_game_requested;
 }
 
 #ifdef TESTS_ENABLED
@@ -83,7 +129,12 @@ void JustAMCPCliArgs::set_test_mcp_port(int p_port) {
 	_test_mcp_port = p_port;
 }
 
+void JustAMCPCliArgs::set_test_mcp_game_port(int p_port) {
+	_test_mcp_game_port = p_port;
+}
+
 void JustAMCPCliArgs::clear_test_overrides() {
 	_test_mcp_port = -1;
+	_test_mcp_game_port = -1;
 }
 #endif

--- a/modules/justamcp/justamcp_cli_args.h
+++ b/modules/justamcp/justamcp_cli_args.h
@@ -8,18 +8,27 @@
 
 #pragma once
 
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+
 class JustAMCPCliArgs {
 public:
+	static bool is_valid_port(int p_port);
 	static int mcp_port();
+	static int mcp_game_port();
 	static bool enable_mcp();
 	static bool enable_mcp_game_control();
 	static bool disable_game_mcp();
 	static bool is_headless();
 	static bool is_unit_test();
 	static bool skip_mcp_server();
+	static bool skip_mcp_server_for_args(const Vector<String> &p_args);
+	static bool should_instantiate_editor_server_for(bool p_skip, bool p_server_enabled);
+	static bool should_instantiate_runtime_for(bool p_skip, bool p_game_requested);
 
 #ifdef TESTS_ENABLED
 	static void set_test_mcp_port(int p_port);
+	static void set_test_mcp_game_port(int p_port);
 	static void clear_test_overrides();
 #endif
 };

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -260,30 +260,34 @@ void JustAMCPEditorPlugin::_notification(int p_what) {
 			if (editor_node) {
 				mcp_server = Object::cast_to<JustAMCPServer>(editor_node->get_node_or_null(NodePath("JustAMCPServer")));
 			}
-			if (!mcp_server) {
-				mcp_server = memnew(JustAMCPServer);
-				mcp_server->set_name("JustAMCPServer");
-				add_child(mcp_server);
-				mcp_server->start_listening();
-			} else {
-				if (!mcp_server->is_inside_tree()) {
+			if (JustAMCPSettingsResolver::should_instantiate_editor_server()) {
+				if (!mcp_server) {
+					mcp_server = memnew(JustAMCPServer);
+					mcp_server->set_name("JustAMCPServer");
 					add_child(mcp_server);
+					mcp_server->start_listening();
+				} else {
+					if (!mcp_server->is_inside_tree()) {
+						add_child(mcp_server);
+					}
+					mcp_server->start_listening();
 				}
-				mcp_server->start_listening();
 			}
 
 			tool_executor = memnew(JustAMCPToolExecutor);
 			tool_executor->set_as_active_instance();
 			tool_executor->set_editor_plugin(this);
 
-			if (!mcp_server->is_connected("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested))) {
-				mcp_server->connect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
-			}
-			if (!mcp_server->is_connected("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled))) {
-				mcp_server->connect("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled));
-			}
-			if (!mcp_server->is_connected("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed))) {
-				mcp_server->connect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
+			if (mcp_server) {
+				if (!mcp_server->is_connected("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested))) {
+					mcp_server->connect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
+				}
+				if (!mcp_server->is_connected("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled))) {
+					mcp_server->connect("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled));
+				}
+				if (!mcp_server->is_connected("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed))) {
+					mcp_server->connect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
+				}
 			}
 
 			_setup_status_indicator();
@@ -436,14 +440,20 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 
 String JustAMCPEditorPlugin::get_mcp_config_json(MCPConfigClient p_client) {
 	int port = JustAMCPSettingsResolver::resolve_server_port();
-	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->get_listening_port() > 0) {
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->get_listening_port() > 0 && !JustAMCPServer::get_singleton()->is_runtime_host()) {
 		port = JustAMCPServer::get_singleton()->get_listening_port();
+	}
+	int game_port = JustAMCPSettingsResolver::resolve_runtime_port();
+	if (game_port == port) {
+		game_port = port + 1;
 	}
 	const bool oauth_enabled = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
 	const String client_id = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_id");
 	const String client_secret = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_secret");
 
 	const String mcp_url = "http://127.0.0.1:" + itos(port) + "/mcp";
+	const String game_url = "http://127.0.0.1:" + itos(game_port) + "/mcp";
+	const bool game_enabled = JustAMCPSettingsResolver::resolve_runtime_enabled();
 
 	if (p_client == MCP_CONFIG_OPENCODE) {
 		String json_config = "{\n";
@@ -453,8 +463,15 @@ String JustAMCPEditorPlugin::get_mcp_config_json(MCPConfigClient p_client) {
 		json_config += "      \"type\": \"remote\",\n";
 		json_config += "      \"url\": \"" + mcp_url + "\",\n";
 		json_config += "      \"enabled\": true\n";
-		json_config += "    }\n";
-		json_config += "  }\n";
+		json_config += "    }";
+		if (game_enabled) {
+			json_config += ",\n    \"blazium-game\": {\n";
+			json_config += "      \"type\": \"remote\",\n";
+			json_config += "      \"url\": \"" + game_url + "\",\n";
+			json_config += "      \"enabled\": true\n";
+			json_config += "    }";
+		}
+		json_config += "\n  }\n";
 		json_config += "}";
 		return json_config;
 	}
@@ -477,8 +494,17 @@ String JustAMCPEditorPlugin::get_mcp_config_json(MCPConfigClient p_client) {
 		json_config += "\n";
 	}
 
-	json_config += "    }\n";
-	json_config += "  }\n";
+	json_config += "    }";
+	if (game_enabled) {
+		json_config += ",\n    \"blazium-game\": {\n";
+		if (p_client == MCP_CONFIG_CURSOR) {
+			json_config += "      \"url\": \"" + game_url + "\"\n";
+		} else {
+			json_config += "      \"serverUrl\": \"" + game_url + "\"\n";
+		}
+		json_config += "    }";
+	}
+	json_config += "\n  }\n";
 	json_config += "}";
 	return json_config;
 }

--- a/modules/justamcp/justamcp_json_rpc_list.cpp
+++ b/modules/justamcp/justamcp_json_rpc_list.cpp
@@ -1,0 +1,120 @@
+/**************************************************************************/
+/*  justamcp_json_rpc_list.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#include "justamcp_mcp_spec.h"
+#include "justamcp_server.h"
+#include "justamcp_session_manager.h"
+#include "tools/justamcp_json_rpc_router.h"
+
+String JustAMCPJsonRpcRouter::extract_list_cursor(const Dictionary &p_payload) {
+	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
+		return String();
+	}
+	const Dictionary params = p_payload["params"];
+	if (!params.has("cursor")) {
+		return String();
+	}
+	return String(params["cursor"]);
+}
+
+Dictionary JustAMCPJsonRpcRouter::finalize_list_result(const Dictionary &p_result, const Variant &p_req_id) {
+	if (p_result.has("ok") && !bool(p_result.get("ok", true))) {
+		Dictionary err;
+		err["handled"] = true;
+		err["jsonrpc"] = "2.0";
+		err["id"] = p_req_id;
+		Dictionary error_dict;
+		error_dict["code"] = p_result.get("error_code", -32602);
+		error_dict["message"] = p_result.get("error", "Invalid params.");
+		err["error"] = error_dict;
+		return err;
+	}
+
+	Dictionary out = p_result.duplicate();
+	out.erase("ok");
+	justamcp_apply_protocol_to_list_result(out, justamcp_active_protocol_version());
+	Dictionary rpc_result;
+	rpc_result["handled"] = true;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_req_id;
+	rpc_result["result"] = out;
+	return rpc_result;
+}
+
+Dictionary JustAMCPJsonRpcRouter::make_invalid_params(const Variant &p_req_id, const String &p_message) {
+	Dictionary err;
+	err["handled"] = true;
+	err["jsonrpc"] = "2.0";
+	err["id"] = p_req_id;
+	Dictionary error_dict;
+	error_dict["code"] = -32602;
+	error_dict["message"] = p_message;
+	err["error"] = error_dict;
+	return err;
+}
+
+Dictionary JustAMCPJsonRpcRouter::route_runtime_host_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id) {
+	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
+		return make_invalid_params(p_req_id, "initialize requires 'params' object.");
+	}
+	const Dictionary params = p_payload["params"];
+	String client_protocol = MCPSessionManager::latest_protocol_version();
+	if (params.has("protocolVersion") && params["protocolVersion"].get_type() == Variant::STRING) {
+		client_protocol = String(params["protocolVersion"]);
+	}
+	const String negotiated = MCPSessionManager::negotiate_legacy_initialize(client_protocol);
+	if (p_server) {
+		p_server->transport_negotiated_protocol = negotiated;
+	}
+
+	Dictionary capabilities;
+	Dictionary tools_cap;
+	tools_cap["listChanged"] = true;
+	capabilities["tools"] = tools_cap;
+	Dictionary prompts_cap;
+	prompts_cap["listChanged"] = true;
+	capabilities["prompts"] = prompts_cap;
+
+	Dictionary serverInfo;
+	serverInfo["name"] = "blazium-game";
+	if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_SERVER_TITLE)) {
+		serverInfo["title"] = "Blazium Game MCP";
+	}
+	serverInfo["version"] = "1.0.0";
+
+	Dictionary result;
+	result["protocolVersion"] = negotiated;
+	result["capabilities"] = capabilities;
+	result["instructions"] = "Project-owned MCP tools and prompts registered from res://mcp. No editor catalog.";
+	result["serverInfo"] = serverInfo;
+
+	Dictionary rpc_result;
+	rpc_result["handled"] = true;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_req_id;
+	rpc_result["result"] = result;
+	return rpc_result;
+}
+
+Dictionary JustAMCPJsonRpcRouter::finalize_action_result(const Dictionary &p_result, const Variant &p_req_id) {
+	Dictionary rpc_result;
+	rpc_result["handled"] = true;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_req_id;
+	if (p_result.get("ok", false)) {
+		Dictionary out = p_result.duplicate();
+		out.erase("ok");
+		rpc_result["result"] = out;
+	} else {
+		Dictionary error_dict;
+		error_dict["code"] = p_result.get("error_code", -32603);
+		error_dict["message"] = p_result.get("error", "Request failed.");
+		rpc_result["error"] = error_dict;
+	}
+	return rpc_result;
+}

--- a/modules/justamcp/justamcp_json_rpc_transport.cpp
+++ b/modules/justamcp/justamcp_json_rpc_transport.cpp
@@ -35,15 +35,19 @@
 
 #include "justamcp_log_levels.h"
 #include "justamcp_mcp_spec.h"
+#include "justamcp_pagination.h"
+#include "justamcp_project_registry.h"
 #include "justamcp_server.h"
 #include "justamcp_session_manager.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_json_rpc_router.h"
+#include "tools/justamcp_settings_resolver.h"
+#ifdef TOOLS_ENABLED
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
-#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_schema_cache.h"
+#endif
 
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
@@ -342,13 +346,18 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 
 	if (method == "initialize") {
 #ifdef TOOLS_ENABLED
-		Dictionary routed = JustAMCPJsonRpcRouter::route_initialize(p_server, payload, req_id_var);
-		if (routed.get("handled", false)) {
-			routed.erase("handled");
-			return routed;
+		if (!p_server || !p_server->is_runtime_host()) {
+			Dictionary routed = JustAMCPJsonRpcRouter::route_initialize(p_server, payload, req_id_var);
+			if (routed.get("handled", false)) {
+				routed.erase("handled");
+				return routed;
+			}
+			return invalid_params("initialize requires 'params' object.");
 		}
 #endif
-		return invalid_params("initialize requires 'params' object.");
+		Dictionary routed = JustAMCPJsonRpcRouter::route_runtime_host_initialize(p_server, payload, req_id_var);
+		routed.erase("handled");
+		return routed;
 	}
 
 	if (method == "ping") {
@@ -368,43 +377,56 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 	if (method == "tools/list") {
 		const String cursor = JustAMCPJsonRpcRouter::extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		Dictionary routed = JustAMCPJsonRpcRouter::route_tools_list(cursor, req_id_var);
-		routed.erase("handled");
-		return routed;
-#else
-		Dictionary empty;
-		empty["ok"] = true;
-		empty["tools"] = Array();
-		Dictionary routed = JustAMCPJsonRpcRouter::finalize_list_result(empty, req_id_var);
-		routed.erase("handled");
-		return routed;
+		if (!p_server || !p_server->is_runtime_host()) {
+			Dictionary routed = JustAMCPJsonRpcRouter::route_tools_list(cursor, req_id_var);
+			routed.erase("handled");
+			return routed;
+		}
 #endif
+		Dictionary page = justamcp_pagination_slice_array(JustAMCPProjectRegistry::list_tool_schemas(), cursor, "tools");
+		Dictionary routed = JustAMCPJsonRpcRouter::finalize_list_result(page, req_id_var);
+		routed.erase("handled");
+		return routed;
 	}
 
 	if (method == "prompts/list") {
 		const String cursor = JustAMCPJsonRpcRouter::extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		Dictionary routed = JustAMCPJsonRpcRouter::route_prompts_list(cursor, req_id_var, p_server->prompt_executor);
-		routed.erase("handled");
-		return routed;
-#else
-		Dictionary empty;
-		empty["ok"] = true;
-		empty["prompts"] = Array();
-		Dictionary routed = JustAMCPJsonRpcRouter::finalize_list_result(empty, req_id_var);
-		routed.erase("handled");
-		return routed;
+		if (!p_server || !p_server->is_runtime_host()) {
+			Dictionary routed = JustAMCPJsonRpcRouter::route_prompts_list(cursor, req_id_var, p_server->prompt_executor);
+			routed.erase("handled");
+			return routed;
+		}
 #endif
+		Dictionary page = justamcp_pagination_slice_array(JustAMCPProjectRegistry::list_prompt_schemas(), cursor, "prompts");
+		Dictionary routed = JustAMCPJsonRpcRouter::finalize_list_result(page, req_id_var);
+		routed.erase("handled");
+		return routed;
 	}
 
 	if (method == "prompts/get") {
 #ifdef TOOLS_ENABLED
-		Dictionary routed = JustAMCPJsonRpcRouter::route_prompts_get(payload, req_id_var, p_server->prompt_executor);
+		if (!p_server || !p_server->is_runtime_host()) {
+			Dictionary routed = JustAMCPJsonRpcRouter::route_prompts_get(payload, req_id_var, p_server->prompt_executor);
+			routed.erase("handled");
+			return routed;
+		}
+#endif
+		if (!payload.has("params") || payload["params"].get_type() != Variant::DICTIONARY) {
+			return invalid_params("prompts/get requires 'params' object.");
+		}
+		const Dictionary prompt_params = payload["params"];
+		if (!prompt_params.has("name") || prompt_params["name"].get_type() != Variant::STRING) {
+			return invalid_params("prompts/get requires 'name' string.");
+		}
+		const String prompt_name = prompt_params["name"];
+		const Dictionary prompt_args = prompt_params.has("arguments") && prompt_params["arguments"].get_type() == Variant::DICTIONARY ? Dictionary(prompt_params["arguments"]) : Dictionary();
+		if (!JustAMCPProjectRegistry::has_prompt(prompt_name)) {
+			return invalid_params("Unknown project prompt: " + prompt_name);
+		}
+		Dictionary routed = JustAMCPJsonRpcRouter::finalize_action_result(JustAMCPProjectRegistry::call_prompt(prompt_name, prompt_args), req_id_var);
 		routed.erase("handled");
 		return routed;
-#else
-		return invalid_params("prompts/get is unavailable.");
-#endif
 	}
 
 	if (method == "notifications/cancelled") {
@@ -521,7 +543,19 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 		args = params.has("arguments") && params["arguments"].get_type() == Variant::DICTIONARY ? Dictionary(params["arguments"]) : Dictionary();
 #endif
 
-#ifdef TOOLS_ENABLED
+		if (JustAMCPProjectRegistry::has_tool(tool_name)) {
+			Dictionary mcp = JustAMCPProjectRegistry::call_tool_mcp(tool_name, args);
+			mcp["id"] = req_id_var;
+			return mcp;
+		}
+
+		if (p_server && p_server->is_runtime_host()) {
+			return invalid_params("Unknown project tool: " + tool_name);
+		}
+
+#ifndef TOOLS_ENABLED
+		return invalid_params("Unknown project tool: " + tool_name);
+#else
 		const String task_support = JustAMCPJsonRpcHelpers::get_tool_task_support(tool_name);
 		const bool has_task_param = params.has("task") && params["task"].get_type() == Variant::DICTIONARY;
 		if (task_support == "forbidden" && has_task_param) {

--- a/modules/justamcp/justamcp_project_registry.cpp
+++ b/modules/justamcp/justamcp_project_registry.cpp
@@ -1,0 +1,179 @@
+/**************************************************************************/
+/*  justamcp_project_registry.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#include "justamcp_project_registry.h"
+
+#include "justamcp_pagination.h"
+#include "tools/justamcp_json_rpc_helpers.h"
+
+#include "core/io/json.h"
+#include "core/variant/variant.h"
+
+HashMap<String, JustAMCPProjectRegistry::ToolEntry> &JustAMCPProjectRegistry::tools() {
+	static HashMap<String, ToolEntry> registry;
+	return registry;
+}
+
+HashMap<String, JustAMCPProjectRegistry::PromptEntry> &JustAMCPProjectRegistry::prompts() {
+	static HashMap<String, PromptEntry> registry;
+	return registry;
+}
+
+bool JustAMCPProjectRegistry::is_valid_entry_name(const String &p_name) {
+	if (p_name.is_empty() || p_name.strip_edges() != p_name) {
+		return false;
+	}
+	if (p_name.begins_with("blazium_")) {
+		return false;
+	}
+	for (int i = 0; i < p_name.length(); i++) {
+		if (p_name[i] <= 32) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void JustAMCPProjectRegistry::register_tool(const String &p_name, const String &p_description, const Dictionary &p_input_schema, const Callable &p_callable) {
+	ERR_FAIL_COND_MSG(!is_valid_entry_name(p_name), "JustAMCP: tool name is empty, contains whitespace, or uses the reserved blazium_ prefix.");
+	ToolEntry entry;
+	entry.name = p_name;
+	entry.description = p_description;
+	entry.input_schema = p_input_schema;
+	entry.callable = p_callable;
+	tools()[p_name] = entry;
+}
+
+void JustAMCPProjectRegistry::unregister_tool(const String &p_name) {
+	tools().erase(p_name);
+}
+
+bool JustAMCPProjectRegistry::has_tool(const String &p_name) {
+	return tools().has(p_name);
+}
+
+Array JustAMCPProjectRegistry::list_tool_schemas() {
+	Array schemas;
+	for (const KeyValue<String, ToolEntry> &E : tools()) {
+		Dictionary schema;
+		schema["name"] = E.value.name;
+		schema["description"] = E.value.description;
+		Dictionary input = E.value.input_schema;
+		if (input.is_empty()) {
+			input["type"] = "object";
+		}
+		schema["inputSchema"] = input;
+		schemas.push_back(schema);
+	}
+	return schemas;
+}
+
+Dictionary JustAMCPProjectRegistry::list_tools() {
+	return justamcp_pagination_slice_array(list_tool_schemas(), String(), "tools");
+}
+
+Dictionary JustAMCPProjectRegistry::call_tool(const String &p_name, const Dictionary &p_args) {
+	Dictionary ret;
+	if (!tools().has(p_name)) {
+		ret["ok"] = false;
+		ret["error"] = "Unknown project tool: " + p_name;
+		return ret;
+	}
+	const ToolEntry &entry = tools()[p_name];
+	if (!entry.callable.is_valid()) {
+		ret["ok"] = false;
+		ret["error"] = "Project tool '" + p_name + "' has no callable.";
+		return ret;
+	}
+	Variant result = entry.callable.call(p_args);
+	ret["ok"] = true;
+	ret["result"] = result;
+	return ret;
+}
+
+Dictionary JustAMCPProjectRegistry::call_tool_mcp(const String &p_name, const Dictionary &p_args) {
+	const Dictionary call = call_tool(p_name, p_args);
+	if (!bool(call.get("ok", false))) {
+		return JustAMCPJsonRpcHelpers::format_tool_result(false, Variant(), String(call.get("error", "Tool call failed.")));
+	}
+	return JustAMCPJsonRpcHelpers::format_tool_result(true, call.get("result", Variant()), String());
+}
+
+void JustAMCPProjectRegistry::register_prompt(const String &p_name, const String &p_description, const Callable &p_callable) {
+	ERR_FAIL_COND_MSG(!is_valid_entry_name(p_name), "JustAMCP: prompt name is empty, contains whitespace, or uses the reserved blazium_ prefix.");
+	PromptEntry entry;
+	entry.name = p_name;
+	entry.description = p_description;
+	entry.callable = p_callable;
+	prompts()[p_name] = entry;
+}
+
+void JustAMCPProjectRegistry::unregister_prompt(const String &p_name) {
+	prompts().erase(p_name);
+}
+
+bool JustAMCPProjectRegistry::has_prompt(const String &p_name) {
+	return prompts().has(p_name);
+}
+
+Array JustAMCPProjectRegistry::list_prompt_schemas() {
+	Array schemas;
+	for (const KeyValue<String, PromptEntry> &E : prompts()) {
+		Dictionary schema;
+		schema["name"] = E.value.name;
+		schema["description"] = E.value.description;
+		schemas.push_back(schema);
+	}
+	return schemas;
+}
+
+Dictionary JustAMCPProjectRegistry::call_prompt(const String &p_name, const Dictionary &p_args) {
+	Dictionary ret;
+	if (!prompts().has(p_name)) {
+		ret["ok"] = false;
+		ret["error"] = "Unknown project prompt: " + p_name;
+		return ret;
+	}
+	const PromptEntry &entry = prompts()[p_name];
+	if (!entry.callable.is_valid()) {
+		ret["ok"] = false;
+		ret["error"] = "Project prompt '" + p_name + "' has no callable.";
+		return ret;
+	}
+	Variant result = entry.callable.call(p_args);
+	ret["ok"] = true;
+	if (result.get_type() == Variant::DICTIONARY) {
+		Dictionary payload = result;
+		if (payload.has("messages") || payload.has("description")) {
+			if (payload.has("messages")) {
+				ret["messages"] = payload["messages"];
+			}
+			if (payload.has("description")) {
+				ret["description"] = payload["description"];
+			}
+			return ret;
+		}
+	}
+	Dictionary message;
+	message["role"] = "user";
+	Array content;
+	Dictionary text;
+	text["type"] = "text";
+	text["text"] = String(result);
+	content.push_back(text);
+	message["content"] = content;
+	Array messages;
+	messages.push_back(message);
+	ret["messages"] = messages;
+	return ret;
+}
+
+void JustAMCPProjectRegistry::clear() {
+	tools().clear();
+	prompts().clear();
+}

--- a/modules/justamcp/justamcp_project_registry.h
+++ b/modules/justamcp/justamcp_project_registry.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  justamcp_project_registry.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+
+class JustAMCPProjectRegistry {
+public:
+	static bool is_valid_entry_name(const String &p_name);
+	static void register_tool(const String &p_name, const String &p_description, const Dictionary &p_input_schema, const Callable &p_callable);
+	static void unregister_tool(const String &p_name);
+	static bool has_tool(const String &p_name);
+	static Array list_tool_schemas();
+	static Dictionary list_tools();
+	static Dictionary call_tool(const String &p_name, const Dictionary &p_args);
+	static Dictionary call_tool_mcp(const String &p_name, const Dictionary &p_args);
+
+	static void register_prompt(const String &p_name, const String &p_description, const Callable &p_callable);
+	static void unregister_prompt(const String &p_name);
+	static bool has_prompt(const String &p_name);
+	static Array list_prompt_schemas();
+	static Dictionary call_prompt(const String &p_name, const Dictionary &p_args);
+
+	static void clear();
+
+private:
+	struct ToolEntry {
+		String name;
+		String description;
+		Dictionary input_schema;
+		Callable callable;
+	};
+	struct PromptEntry {
+		String name;
+		String description;
+		Callable callable;
+	};
+
+	static HashMap<String, ToolEntry> &tools();
+	static HashMap<String, PromptEntry> &prompts();
+};

--- a/modules/justamcp/justamcp_project_settings.cpp
+++ b/modules/justamcp/justamcp_project_settings.cpp
@@ -41,7 +41,15 @@
 void JustAMCPProjectSettings::register_project_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/override_editor_settings", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/server_enabled", false);
+	GLOBAL_DEF_BASIC("blazium/justamcp/game_control_enabled", false);
+	GLOBAL_DEF_BASIC("blazium/justamcp/disable_game_mcp", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/server_port", 6506);
+	GLOBAL_DEF_BASIC("blazium/justamcp/export_port", 0);
+	GLOBAL_DEF_BASIC("blazium/justamcp/project_mcp_dir", "res://mcp");
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::INT, "blazium/justamcp/export_port", PROPERTY_HINT_RANGE, "0,65535,1"));
+		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "blazium/justamcp/project_mcp_dir", PROPERTY_HINT_DIR));
+	}
 	GLOBAL_DEF_BASIC("blazium/justamcp/protocol_version", "2026-07-28");
 	if (ProjectSettings::get_singleton()) {
 		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "blazium/justamcp/protocol_version", PROPERTY_HINT_ENUM, "2026-07-28,2025-11-25,2025-06-18,2025-03-26,2024-11-05"));
@@ -95,8 +103,20 @@ void JustAMCPProjectSettings::register_editor_settings() {
 	EDITOR_DEF_BASIC("blazium/justamcp/server_enabled", false);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/server_enabled"));
 
+	EDITOR_DEF_BASIC("blazium/justamcp/game_control_enabled", false);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/game_control_enabled"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/disable_game_mcp", false);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/disable_game_mcp"));
+
 	EDITOR_DEF_BASIC("blazium/justamcp/server_port", 6506);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/server_port"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/export_port", 0);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/export_port", PROPERTY_HINT_RANGE, "0,65535,1"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/project_mcp_dir", "res://mcp");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/project_mcp_dir", PROPERTY_HINT_DIR));
 
 	EDITOR_DEF_BASIC("blazium/justamcp/protocol_version", "2026-07-28");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/protocol_version", PROPERTY_HINT_ENUM, "2026-07-28,2025-11-25,2025-06-18,2025-03-26,2024-11-05"));

--- a/modules/justamcp/justamcp_runtime.cpp
+++ b/modules/justamcp/justamcp_runtime.cpp
@@ -29,6 +29,11 @@
 
 #include "justamcp_runtime.h"
 
+#include "justamcp_project_registry.h"
+#include "justamcp_server.h"
+#include "tools/justamcp_settings_resolver.h"
+
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/input/input.h"
@@ -36,7 +41,9 @@
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/io/json.h"
+#include "core/io/resource_loader.h"
 #include "core/math/expression.h"
+#include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
@@ -45,13 +52,14 @@
 #include "scene/gui/base_button.h"
 #include "scene/gui/control.h"
 #include "scene/main/multiplayer_api.h"
+#include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
 #include "servers/audio_server.h"
-#include "tools/justamcp_tool_executor.h"
-
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
+#include "tools/justamcp_tool_executor.h"
 #endif
 
 JustAMCPRuntime *JustAMCPRuntime::singleton = nullptr;
@@ -89,6 +97,13 @@ void JustAMCPRuntime::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("register_custom_command", "name", "callable"), &JustAMCPRuntime::register_custom_command);
 	ClassDB::bind_method(D_METHOD("unregister_custom_command", "name"), &JustAMCPRuntime::unregister_custom_command);
+	ClassDB::bind_method(D_METHOD("register_tool", "name", "description", "input_schema", "callable"), &JustAMCPRuntime::register_tool);
+	ClassDB::bind_method(D_METHOD("unregister_tool", "name"), &JustAMCPRuntime::unregister_tool);
+	ClassDB::bind_method(D_METHOD("register_prompt", "name", "description", "callable"), &JustAMCPRuntime::register_prompt);
+	ClassDB::bind_method(D_METHOD("unregister_prompt", "name"), &JustAMCPRuntime::unregister_prompt);
+	ClassDB::bind_method(D_METHOD("list_tools"), &JustAMCPRuntime::list_tools);
+	ClassDB::bind_method(D_METHOD("is_listening"), &JustAMCPRuntime::is_listening);
+	ClassDB::bind_method(D_METHOD("load_project_mcp_scripts"), &JustAMCPRuntime::load_project_mcp_scripts);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "port"), "set_port", "get_port");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
@@ -108,8 +123,10 @@ JustAMCPRuntime::JustAMCPRuntime() {
 		return;
 	}
 
+#ifdef TOOLS_ENABLED
 	executor = memnew(JustAMCPToolExecutor);
 	executor->set_as_active_instance();
+#endif
 
 	_print_handler.printfunc = _print_handler_callback;
 	_print_handler.userdata = this;
@@ -129,4 +146,116 @@ JustAMCPRuntime::~JustAMCPRuntime() {
 		singleton = nullptr;
 	}
 	_cleanup();
+}
+
+void JustAMCPRuntime::register_tool(const String &p_name, const String &p_description, const Dictionary &p_input_schema, const Callable &p_callable) {
+	JustAMCPProjectRegistry::register_tool(p_name, p_description, p_input_schema, p_callable);
+#ifdef TOOLS_ENABLED
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->is_server_started()) {
+		JustAMCPServer::get_singleton()->broadcast_tools_list_changed();
+	}
+#endif
+}
+
+void JustAMCPRuntime::unregister_tool(const String &p_name) {
+	JustAMCPProjectRegistry::unregister_tool(p_name);
+}
+
+void JustAMCPRuntime::register_prompt(const String &p_name, const String &p_description, const Callable &p_callable) {
+	JustAMCPProjectRegistry::register_prompt(p_name, p_description, p_callable);
+#ifdef TOOLS_ENABLED
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->is_server_started()) {
+		JustAMCPServer::get_singleton()->broadcast_prompts_list_changed();
+	}
+#endif
+}
+
+void JustAMCPRuntime::unregister_prompt(const String &p_name) {
+	JustAMCPProjectRegistry::unregister_prompt(p_name);
+#ifdef TOOLS_ENABLED
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->is_server_started()) {
+		JustAMCPServer::get_singleton()->broadcast_prompts_list_changed();
+	}
+#endif
+}
+
+void JustAMCPRuntime::_debug_print(const String &p_message) {
+	if (JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false)) {
+		print_line(p_message);
+	}
+}
+
+bool JustAMCPRuntime::is_valid_project_mcp_dir(const String &p_dir) {
+	const String dir = p_dir.strip_edges();
+	if (!dir.begins_with("res://")) {
+		return false;
+	}
+	const String rest = dir.substr(String("res://").length());
+	if (rest.is_empty()) {
+		return true;
+	}
+	if (rest.begins_with("/") || rest.contains("..") || rest.contains("//")) {
+		return false;
+	}
+	return true;
+}
+
+Array JustAMCPRuntime::list_tools() const {
+	return JustAMCPProjectRegistry::list_tool_schemas();
+}
+
+bool JustAMCPRuntime::is_listening() const {
+	if (http_host && http_host->is_server_started()) {
+		return true;
+	}
+	return enabled && server.is_valid() && server->is_listening();
+}
+
+void JustAMCPRuntime::load_project_mcp_scripts() {
+	if (project_scripts_loaded) {
+		return;
+	}
+	project_scripts_loaded = true;
+	const String dir = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/project_mcp_dir", "res://mcp");
+	if (!is_valid_project_mcp_dir(dir)) {
+		ERR_PRINT("JustAMCP: blazium/justamcp/project_mcp_dir must be a res:// path without '..'.");
+		return;
+	}
+	Vector<String> scripts;
+	scripts.push_back(dir.path_join("register.gd"));
+	scripts.push_back(dir.path_join("register.luau"));
+	for (int i = 0; i < scripts.size(); i++) {
+		const String path = scripts[i];
+		if (!ResourceLoader::exists(path)) {
+			continue;
+		}
+		Ref<Resource> res = ResourceLoader::load(path);
+		Ref<Script> mcp_script = res;
+		if (mcp_script.is_null() || !mcp_script->can_instantiate()) {
+			WARN_PRINT("JustAMCP: Could not instantiate project MCP script " + path);
+			continue;
+		}
+		const StringName base = mcp_script->get_instance_base_type();
+		if (base == StringName() || !ClassDB::can_instantiate(base)) {
+			WARN_PRINT("JustAMCP: Project MCP script " + path + " has no instantiable base type.");
+			continue;
+		}
+		Object *inst = ClassDB::instantiate(base);
+		if (!inst) {
+			continue;
+		}
+		inst->set_script(mcp_script);
+		if (Node *node = Object::cast_to<Node>(inst)) {
+			if (SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop())) {
+				if (tree->get_root()) {
+					tree->get_root()->add_child(node);
+				}
+			}
+		}
+		project_mcp_instances.push_back(inst);
+		if (inst->has_method("register")) {
+			inst->call("register");
+		}
+		_debug_print("JustAMCP: Loaded project MCP script " + path);
+	}
 }

--- a/modules/justamcp/justamcp_runtime.h
+++ b/modules/justamcp/justamcp_runtime.h
@@ -47,7 +47,7 @@ private:
 	Vector<Ref<StreamPeerTCP>> clients;
 	HashMap<Ref<StreamPeerTCP>, String> client_buffers;
 	Mutex clients_mutex;
-	int port = 6506;
+	int port = 6507;
 	bool enabled = false;
 	Thread *server_thread = nullptr;
 	std::atomic<bool> quit_thread{ false };
@@ -61,6 +61,9 @@ private:
 	Vector<uint64_t> _screenshot_timestamps;
 
 	class JustAMCPToolExecutor *executor = nullptr;
+	class JustAMCPServer *http_host = nullptr;
+	Vector<Object *> project_mcp_instances;
+	bool project_scripts_loaded = false;
 
 	Vector<Dictionary> _error_log;
 	Mutex _error_log_mutex;
@@ -70,6 +73,7 @@ private:
 	static const char *_BLOCKED_METHODS[];
 	static const char *_EVAL_BLOCKED_PATTERNS[];
 
+	static void _debug_print(const String &p_message);
 	void _start_server();
 	void _send_welcome(Ref<StreamPeerTCP> p_client);
 	void _handle_message(Ref<StreamPeerTCP> p_client, const String &p_data);
@@ -164,6 +168,16 @@ public:
 
 	void register_custom_command(const String &p_name, const Callable &p_callable);
 	void unregister_custom_command(const String &p_name);
+
+	void register_tool(const String &p_name, const String &p_description, const Dictionary &p_input_schema, const Callable &p_callable);
+	void unregister_tool(const String &p_name);
+	void register_prompt(const String &p_name, const String &p_description, const Callable &p_callable);
+	void unregister_prompt(const String &p_name);
+	Array list_tools() const;
+	bool is_listening() const;
+
+	static bool is_valid_project_mcp_dir(const String &p_dir);
+	void load_project_mcp_scripts();
 
 	JustAMCPRuntime();
 	~JustAMCPRuntime();

--- a/modules/justamcp/justamcp_runtime_commands.cpp
+++ b/modules/justamcp/justamcp_runtime_commands.cpp
@@ -42,6 +42,7 @@
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
+#include "justamcp_project_registry.h"
 #include "justamcp_read_limits.h"
 #include "main/performance.h"
 #include "scene/gui/base_button.h"
@@ -50,11 +51,11 @@
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
 #include "servers/audio_server.h"
-#include "tools/justamcp_tool_executor.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_interface.h"
 #include "editor/editor_settings.h"
+#include "tools/justamcp_tool_executor.h"
 #endif
 
 Dictionary JustAMCPRuntime::execute_command(const String &p_command, const Dictionary &p_params) {
@@ -317,13 +318,6 @@ void JustAMCPRuntime::unregister_custom_command(const String &p_name) {
 	_custom_commands.erase(p_name);
 }
 Dictionary JustAMCPRuntime::_cmd_tool_call(const Dictionary &p_params) {
-	if (!executor) {
-		Dictionary ret;
-		ret["type"] = "error";
-		ret["message"] = "Tool executor not initialized";
-		return ret;
-	}
-
 	String tool_name = p_params.get("name", "");
 	Dictionary tool_args = p_params.get("args", Dictionary());
 
@@ -334,13 +328,31 @@ Dictionary JustAMCPRuntime::_cmd_tool_call(const Dictionary &p_params) {
 		return ret;
 	}
 
-	return executor->execute_tool(tool_name, tool_args);
+	if (JustAMCPProjectRegistry::has_tool(tool_name)) {
+		return JustAMCPProjectRegistry::call_tool(tool_name, tool_args);
+	}
+
+#ifdef TOOLS_ENABLED
+	if (executor) {
+		return executor->execute_tool(tool_name, tool_args);
+	}
+#endif
+	Dictionary ret;
+	ret["type"] = "error";
+	ret["message"] = "Unknown project tool: " + tool_name;
+	return ret;
 }
 
 Dictionary JustAMCPRuntime::_cmd_list_tools(const Dictionary &p_params) {
 	Dictionary ret;
 	ret["type"] = "tool_list";
-	ret["tools"] = JustAMCPToolExecutor::get_tool_schemas(false, true);
+#ifdef TOOLS_ENABLED
+	if (executor) {
+		ret["tools"] = JustAMCPToolExecutor::get_tool_schemas(false, true);
+		return ret;
+	}
+#endif
+	ret["tools"] = JustAMCPProjectRegistry::list_tool_schemas();
 	return ret;
 }
 Dictionary JustAMCPRuntime::_cmd_get_log_tail(const Dictionary &p_params) {

--- a/modules/justamcp/justamcp_runtime_tcp.cpp
+++ b/modules/justamcp/justamcp_runtime_tcp.cpp
@@ -29,14 +29,21 @@
 
 #include "justamcp_runtime.h"
 
+#include "justamcp_cli_args.h"
+#include "justamcp_server.h"
+#include "tools/justamcp_settings_resolver.h"
+
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
-#include "justamcp_cli_args.h"
-#include "tools/justamcp_settings_resolver.h"
+#include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
+#ifdef TOOLS_ENABLED
 #include "tools/justamcp_tool_executor.h"
+#endif
 
 void JustAMCPRuntime::_thread_poll_wrapper(void *p_user) {
 	JustAMCPRuntime *runtime = (JustAMCPRuntime *)p_user;
@@ -79,7 +86,7 @@ void JustAMCPRuntime::poll() {
 		for (int i = 0; i < accepted_clients.size(); i++) {
 			Ref<StreamPeerTCP> client = accepted_clients[i];
 			clients.push_back(client);
-			print_line("[MCP Runtime] Client connected");
+			_debug_print("[MCP Runtime] Client connected");
 			call_deferred("emit_signal", "client_connected");
 			_send_welcome(client);
 		}
@@ -123,7 +130,7 @@ void JustAMCPRuntime::poll() {
 			Ref<StreamPeerTCP> c = clients_to_remove[i];
 			clients.erase(c);
 			client_buffers.erase(c);
-			print_line("[MCP Runtime] Client disconnected");
+			_debug_print("[MCP Runtime] Client disconnected");
 			call_deferred("emit_signal", "client_disconnected");
 		}
 	}
@@ -184,25 +191,47 @@ void JustAMCPRuntime::push_error_log(const String &p_message, bool p_is_error) {
 	}
 }
 
+static void _justamcp_load_project_scripts_idle() {
+	if (JustAMCPRuntime *runtime = JustAMCPRuntime::get_singleton()) {
+		runtime->load_project_mcp_scripts();
+	}
+}
+
 void JustAMCPRuntime::_start_server() {
 	if (JustAMCPCliArgs::skip_mcp_server()) {
 		return;
 	}
-	if (JustAMCPCliArgs::disable_game_mcp() || JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/disable_game_mcp", false)) {
+	if (!JustAMCPSettingsResolver::resolve_runtime_enabled()) {
 		return;
 	}
 
-	port = JustAMCPSettingsResolver::resolve_server_port();
-	const bool game_control = JustAMCPCliArgs::enable_mcp_game_control() ||
-			JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/game_control_enabled", false);
-	if (JustAMCPCliArgs::enable_mcp() || game_control) {
-		enabled = true;
-	} else {
-		enabled = JustAMCPSettingsResolver::resolve_server_enabled();
-	}
-
-	if (!enabled) {
+	port = JustAMCPSettingsResolver::resolve_runtime_port();
+	if (JustAMCPSettingsResolver::runtime_port_conflicts_with_editor()) {
+		ERR_PRINT(vformat("[MCP Runtime] Game port %d equals the editor MCP port. Set blazium/justamcp/export_port or --mcp-game-port.", port));
 		return;
+	}
+	enabled = true;
+
+	bool start_http_host = true;
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		start_http_host = false;
+	}
+#endif
+	if (start_http_host) {
+		if (!http_host) {
+			http_host = memnew(JustAMCPServer);
+			http_host->set_runtime_host(true);
+		}
+		http_host->start_listening();
+		if (http_host->is_server_started() && http_host->get_listening_port() > 0) {
+			port = http_host->get_listening_port();
+		}
+		if (Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop())) {
+			load_project_mcp_scripts();
+		} else {
+			SceneTree::add_idle_callback(_justamcp_load_project_scripts_idle);
+		}
 	}
 
 	if (server.is_valid() && server->is_listening()) {
@@ -212,13 +241,34 @@ void JustAMCPRuntime::_start_server() {
 	const bool bind_to_localhost = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/bind_to_localhost_only", true);
 	String bind_address = bind_to_localhost ? "127.0.0.1" : "*";
 
-	Error err = server->listen(port, bind_address);
+	int tcp_port = port;
+	if (http_host && http_host->is_server_started()) {
+		tcp_port = port + 1;
+		if (tcp_port == JustAMCPSettingsResolver::resolve_server_port()) {
+			tcp_port++;
+		}
+	}
+
+	Error err = server->listen(tcp_port, bind_address);
 	if (err != OK) {
-		ERR_PRINT(vformat("[MCP Runtime] Failed to start server on port %d: %d", port, err));
-		enabled = false;
+		const int retry_port = tcp_port + 1;
+		if (retry_port != JustAMCPSettingsResolver::resolve_server_port()) {
+			err = server->listen(retry_port, bind_address);
+			if (err == OK) {
+				tcp_port = retry_port;
+			}
+		}
+	}
+	if (err != OK) {
+		ERR_PRINT(vformat("[MCP Runtime] Failed to start TCP bridge on port %d: %d", tcp_port, err));
+		if (!http_host || !http_host->is_server_started()) {
+			enabled = false;
+		}
 	} else {
-		print_line(vformat("[MCP Runtime] Server listening on port %d", port));
-		print_line(vformat("BLAZIUM_READY:{\"proto\":\"blazium/1\",\"port\":%d,\"engine\":\"Blazium\"}", port));
+		_debug_print(vformat("[MCP Runtime] TCP bridge listening on port %d", tcp_port));
+		if (!http_host || !http_host->is_server_started()) {
+			print_line(vformat("BLAZIUM_READY:{\"proto\":\"blazium/1\",\"port\":%d,\"engine\":\"Blazium\"}", tcp_port));
+		}
 		quit_thread = false;
 		if (!server_thread) {
 			server_thread = memnew(Thread);
@@ -226,6 +276,10 @@ void JustAMCPRuntime::_start_server() {
 		if (!server_thread->is_started()) {
 			server_thread->start(_thread_poll_wrapper, this);
 		}
+	}
+	if (http_host && http_host->is_server_started()) {
+		_debug_print(vformat("[MCP Runtime] HTTP MCP host listening on port %d", port));
+		print_line(vformat("BLAZIUM_READY:{\"proto\":\"blazium/1\",\"port\":%d,\"engine\":\"Blazium\",\"mcp\":\"http://127.0.0.1:%d/mcp\"}", port, port));
 	}
 }
 
@@ -239,10 +293,29 @@ void JustAMCPRuntime::_cleanup() {
 		server_thread = nullptr;
 	}
 
+#ifdef TOOLS_ENABLED
 	if (executor) {
 		memdelete(executor);
 		executor = nullptr;
 	}
+#endif
+	if (http_host) {
+		memdelete(http_host);
+		http_host = nullptr;
+	}
+	for (int i = 0; i < project_mcp_instances.size(); i++) {
+		if (Object *inst = project_mcp_instances[i]) {
+			if (Node *node = Object::cast_to<Node>(inst)) {
+				if (node->is_inside_tree()) {
+					node->queue_free();
+					continue;
+				}
+			}
+			memdelete(inst);
+		}
+	}
+	project_mcp_instances.clear();
+	project_scripts_loaded = false;
 
 	{
 		MutexLock lock(clients_mutex);

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -34,34 +34,29 @@
 #include "justamcp_json_rpc_transport.h"
 #include "justamcp_notification_bus.h"
 #include "justamcp_pagination.h"
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
 #include "justamcp_project_settings.h"
-#include "justamcp_server_request_lookup.h"
-#include "justamcp_session_manager.h"
 #include "justamcp_tool_dispatch.h"
-#include "justamcp_tool_queue_state.h"
-#include "tools/justamcp_json_rpc_helpers.h"
-#include "tools/justamcp_json_rpc_router.h"
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
-#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
 #include "tools/justamcp_tool_schema_cache.h"
+#endif
+#include "justamcp_server_request_lookup.h"
+#include "justamcp_session_manager.h"
+#include "justamcp_tool_queue_state.h"
+#include "tools/justamcp_json_rpc_helpers.h"
+#include "tools/justamcp_json_rpc_router.h"
+#include "tools/justamcp_settings_resolver.h"
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
-#include "editor/editor_settings.h"
 
 #include "modules/modules_enabled.gen.h"
-
-static bool _justamcp_headless_project_server_requested() {
-	if (!JustAMCPCliArgs::is_headless()) {
-		return false;
-	}
-	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/server_enabled", false);
-}
 
 void JustAMCPServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_server_started"), &JustAMCPServer::is_server_started);
@@ -377,17 +372,16 @@ void JustAMCPServer::_notification(int p_what) {
 }
 
 int JustAMCPServer::_resolve_listening_port_from_settings() const {
+	if (runtime_host) {
+		return JustAMCPSettingsResolver::resolve_runtime_port();
+	}
 	return JustAMCPSettingsResolver::resolve_server_port();
 }
 
 void JustAMCPServer::_on_settings_changed() {
 #ifdef TOOLS_ENABLED
 	JustAMCPJsonRpcHelpers::mark_mcp_tool_settings_dirty();
-	bool is_enabled = JustAMCPSettingsResolver::resolve_server_enabled();
-
-	if (_justamcp_headless_project_server_requested()) {
-		is_enabled = true;
-	}
+	bool is_enabled = runtime_host ? JustAMCPSettingsResolver::resolve_runtime_enabled() : JustAMCPSettingsResolver::resolve_server_enabled();
 
 	if (!is_enabled && server_started) {
 		_stop_server();
@@ -426,13 +420,17 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 	}
 
 	const List<String> &args = OS::get_singleton()->get_cmdline_args();
-	if (!p_ignore_cmdline_block && JustAMCPCliArgs::skip_mcp_server() && !_justamcp_headless_project_server_requested()) {
+	if (!p_ignore_cmdline_block && JustAMCPCliArgs::skip_mcp_server()) {
 		print_line("JustAMCP: Server not started (cmdline skips MCP).");
 		return;
 	}
 
-	bool enabled = JustAMCPSettingsResolver::resolve_server_enabled();
-	int port = JustAMCPSettingsResolver::resolve_server_port();
+	bool enabled = runtime_host ? JustAMCPSettingsResolver::resolve_runtime_enabled() : JustAMCPSettingsResolver::resolve_server_enabled();
+	int port = _resolve_listening_port_from_settings();
+	if (runtime_host && JustAMCPSettingsResolver::runtime_port_conflicts_with_editor()) {
+		ERR_PRINT("JustAMCP: Game MCP port " + itos(port) + " equals the editor port. Set blazium/justamcp/export_port or --mcp-game-port to a different value.");
+		return;
+	}
 	bool bind_to_localhost = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/bind_to_localhost_only", true);
 
 	String cmd_client_id = "";
@@ -478,7 +476,11 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 	}
 
 	if (!enabled) {
-		print_line("JustAMCP: Server not started (disabled; pass --enable-mcp or set blazium/justamcp/server_enabled).");
+		if (runtime_host) {
+			print_line("JustAMCP: Game MCP host not started (disabled; pass --enable-mcp or --enable-mcp-game-control, or set blazium/justamcp/game_control_enabled).");
+		} else {
+			print_line("JustAMCP: Server not started (disabled; pass --enable-mcp or set blazium/justamcp/server_enabled).");
+		}
 		return;
 	}
 
@@ -504,6 +506,22 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 #endif
 		{
 			listen_err = HTTPServer::get_singleton()->listen(port, bind_address, false);
+		}
+		if (listen_err != OK && runtime_host) {
+			const int retry_port = port + 1;
+			const int editor_port = JustAMCPSettingsResolver::resolve_server_port();
+			if (retry_port > 0 && retry_port != editor_port) {
+#ifdef TESTS_ENABLED
+				if (test_forced_listen_error == OK)
+#endif
+				{
+					listen_err = HTTPServer::get_singleton()->listen(retry_port, bind_address, false);
+				}
+				if (listen_err == OK) {
+					WARN_PRINT("JustAMCP: Game MCP port " + itos(port) + " was busy (remote_control also defaults to 6507). Listening on " + itos(retry_port) + ". Set blazium/justamcp/export_port to pin the game port.");
+					port = retry_port;
+				}
+			}
 		}
 		if (listen_err != OK) {
 #ifdef TESTS_ENABLED

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -81,6 +81,7 @@ private:
 
 	int current_sse_connection_id = -1;
 	bool server_started = false;
+	bool runtime_host = false;
 	int active_listening_port = -1;
 	HashMap<String, Vector<uint64_t>> session_enqueue_timestamps_usec;
 	Mutex session_enqueue_rate_mutex;
@@ -273,6 +274,8 @@ public:
 #endif
 
 	void start_listening();
+	void set_runtime_host(bool p_runtime_host) { runtime_host = p_runtime_host; }
+	bool is_runtime_host() const { return runtime_host; }
 	bool is_server_started() const { return server_started; }
 	int get_listening_port() const { return active_listening_port; }
 	int get_pending_tool_queue_size();

--- a/modules/justamcp/justamcp_server_http.cpp
+++ b/modules/justamcp/justamcp_server_http.cpp
@@ -46,6 +46,7 @@
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
+#ifdef TOOLS_ENABLED
 static bool _justamcp_secure_string_equal(const String &p_a, const String &p_b, bool &r_crypto_available) {
 	Ref<Crypto> crypto = Ref<Crypto>(Crypto::create());
 	if (crypto.is_null()) {
@@ -55,6 +56,7 @@ static bool _justamcp_secure_string_equal(const String &p_a, const String &p_b, 
 	r_crypto_available = true;
 	return crypto->constant_time_compare(p_a.to_utf8_buffer(), p_b.to_utf8_buffer());
 }
+#endif
 
 static String _justamcp_redact_header_value(const String &p_key, const String &p_value) {
 	const String key = p_key.to_lower();

--- a/modules/justamcp/justamcp_server_results.cpp
+++ b/modules/justamcp/justamcp_server_results.cpp
@@ -36,8 +36,10 @@
 #include "justamcp_tool_dispatch.h"
 #include "justamcp_tool_queue_state.h"
 #include "tools/justamcp_json_rpc_helpers.h"
+#ifdef TOOLS_ENABLED
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
+#endif
 
 #include "core/config/project_settings.h"
 #include "core/io/json.h"

--- a/modules/justamcp/justamcp_server_tool_lifecycle.cpp
+++ b/modules/justamcp/justamcp_server_tool_lifecycle.cpp
@@ -49,9 +49,9 @@ void JustAMCPServer::_complete_task_tool_entry(MCPToolQueueEntry *p_entry, bool 
 
 	const String progress_token = p_entry->progress_token;
 	const String task_id = p_entry->task_id;
-	const bool was_cancelled = p_entry->cancel_requested || String(p_error) == "cancelled" || (p_result.get_type() == Variant::DICTIONARY && String(Dictionary(p_result).get("error", "")) == "cancelled");
 
 #ifdef TOOLS_ENABLED
+	const bool was_cancelled = p_entry->cancel_requested || String(p_error) == "cancelled" || (p_result.get_type() == Variant::DICTIONARY && String(Dictionary(p_result).get("error", "")) == "cancelled");
 	if (task_manager && !task_id.is_empty()) {
 		if (was_cancelled) {
 			task_manager->cancel_task_execution(task_id);

--- a/modules/justamcp/justamcp_server_tool_queue.cpp
+++ b/modules/justamcp/justamcp_server_tool_queue.cpp
@@ -43,8 +43,10 @@
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_readonly_tools.h"
 #include "tools/justamcp_settings_resolver.h"
+#ifdef TOOLS_ENABLED
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
+#endif
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 

--- a/modules/justamcp/justamcp_session_manager.cpp
+++ b/modules/justamcp/justamcp_session_manager.cpp
@@ -136,6 +136,22 @@ String MCPSessionManager::first_protocol_version_token(const String &p_header) {
 	return String();
 }
 
+bool MCPSessionManager::protocol_header_allows_legacy_sse(const String &p_header) {
+	const Vector<String> parts = p_header.split(",", false);
+	bool saw_version = false;
+	for (int i = 0; i < parts.size(); i++) {
+		const String version = parts[i].strip_edges();
+		if (version.is_empty()) {
+			continue;
+		}
+		saw_version = true;
+		if (is_legacy_protocol_version(version)) {
+			return true;
+		}
+	}
+	return !saw_version;
+}
+
 Dictionary MCPSessionManager::header_mismatch_error(const Variant &p_id, const String &p_message) {
 	Dictionary err;
 	err["jsonrpc"] = "2.0";

--- a/modules/justamcp/justamcp_session_manager.h
+++ b/modules/justamcp/justamcp_session_manager.h
@@ -117,6 +117,7 @@ public:
 	static Dictionary header_mismatch_error(const Variant &p_id, const String &p_message);
 	static Dictionary mcp_server_info();
 	static String first_protocol_version_token(const String &p_header);
+	static bool protocol_header_allows_legacy_sse(const String &p_header);
 	static String decode_mcp_header_value(const String &p_value);
 	static String protocol_version_from_payload(const Dictionary &p_payload);
 	static void decorate_modern_rpc(Dictionary &p_rpc, const String &p_method);

--- a/modules/justamcp/justamcp_session_manager_http_get.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_get.cpp
@@ -84,11 +84,11 @@ bool MCPSessionManager::handle_mcp_get(const Ref<HTTPRequestContext> &p_context,
 		p_response->set_status(403);
 		return true;
 	}
-	const String requested = first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version"));
-	if (is_modern_protocol_version(requested)) {
+	const String protocol_header = get_header(p_context, "MCP-Protocol-Version");
+	if (!protocol_header_allows_legacy_sse(protocol_header)) {
 		apply_cors_headers(p_response, p_context);
 		p_response->set_status(405);
-		p_response->set_body("GET is not supported for protocol " + requested);
+		p_response->set_body("GET is not supported for protocol " + first_protocol_version_token(protocol_header));
 		return true;
 	}
 	if (!accepts_event_stream(p_context)) {
@@ -110,6 +110,13 @@ bool MCPSessionManager::handle_mcp_get(const Ref<HTTPRequestContext> &p_context,
 	if (!session) {
 		p_response->set_status(404);
 		p_response->set_body("Unknown or expired MCP session");
+		return true;
+	}
+	if (is_modern_protocol_version(session->negotiated_protocol)) {
+		lock.temp_unlock();
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(405);
+		p_response->set_body("GET is not supported for protocol " + session->negotiated_protocol);
 		return true;
 	}
 	_touch_session(*session);

--- a/modules/justamcp/justamcp_tool_dispatch.cpp
+++ b/modules/justamcp/justamcp_tool_dispatch.cpp
@@ -29,6 +29,8 @@
 
 #include "justamcp_tool_dispatch.h"
 
+#ifdef TOOLS_ENABLED
+
 #include "justamcp_mcp_spec.h"
 #include "justamcp_server.h"
 #include "justamcp_tool_context.h"
@@ -178,3 +180,5 @@ bool JustAMCPToolDispatch::try_schedule_worker_execute(JustAMCPServer *p_server,
 	executor->track_worker_task(task_id);
 	return true;
 }
+
+#endif

--- a/modules/justamcp/justamcp_tool_dispatch.h
+++ b/modules/justamcp/justamcp_tool_dispatch.h
@@ -37,7 +37,23 @@ class JustAMCPToolExecutor;
 
 class JustAMCPToolDispatch {
 public:
+#ifdef TOOLS_ENABLED
 	static void execute_and_send(JustAMCPServer *p_server, JustAMCPToolExecutor *p_executor, const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args);
-
 	static bool try_schedule_worker_execute(JustAMCPServer *p_server, const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args);
+#else
+	static void execute_and_send(JustAMCPServer *p_server, JustAMCPToolExecutor *p_executor, const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args) {
+		(void)p_server;
+		(void)p_executor;
+		(void)p_request_id;
+		(void)p_tool_name;
+		(void)p_args;
+	}
+	static bool try_schedule_worker_execute(JustAMCPServer *p_server, const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args) {
+		(void)p_server;
+		(void)p_request_id;
+		(void)p_tool_name;
+		(void)p_args;
+		return false;
+	}
+#endif
 };

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -34,9 +34,11 @@
 
 #include "justamcp_cli_args.h"
 #include "justamcp_runtime.h"
+#include "justamcp_server.h"
 #include "tools/justamcp_settings_resolver.h"
 
 #include "core/config/engine.h"
+#include "core/config/project_settings.h"
 
 #ifdef TOOLS_ENABLED
 #include "core/config/project_settings.h"
@@ -93,7 +95,7 @@
 #include "tools/resources/justamcp_resource_project_file.h"
 #endif
 
-#ifdef TESTS_ENABLED
+#if defined(TESTS_ENABLED) && defined(TOOLS_ENABLED)
 #include "tests/test_justamcp_agent_helpers.cpp"
 #include "tests/test_justamcp_analysis_read_cap.cpp"
 #include "tests/test_justamcp_asset_tags_tools.cpp"
@@ -133,6 +135,7 @@
 #include "tests/test_justamcp_resource_providers.cpp"
 #include "tests/test_justamcp_resource_read_caps.cpp"
 #include "tests/test_justamcp_routing_dispatch.cpp"
+#include "tests/test_justamcp_runtime_export.cpp"
 #include "tests/test_justamcp_runtime_smoke.cpp"
 #include "tests/test_justamcp_schema_cache_concurrent.cpp"
 #include "tests/test_justamcp_schema_dirty_per_cache_key.cpp"
@@ -156,20 +159,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #endif
-
-static bool _is_justamcp_editor_enabled() {
-	return JustAMCPSettingsResolver::resolve_server_enabled();
-}
-
-static bool _is_justamcp_game_control_requested() {
-	if (JustAMCPCliArgs::disable_game_mcp() || JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/disable_game_mcp", false)) {
-		return false;
-	}
-	if (JustAMCPCliArgs::enable_mcp_game_control()) {
-		return true;
-	}
-	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/game_control_enabled", false);
-}
 
 #ifdef TOOLS_ENABLED
 static void _register_category_toolset(const String &p_name, const String &p_category, const String &p_description) {
@@ -210,22 +199,25 @@ static void _register_all_toolsets() {
 void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(JustAMCPRuntime);
+		GDREGISTER_CLASS(JustAMCPServer);
 		GLOBAL_DEF_BASIC("blazium/justamcp/game_control_enabled", false);
 		GLOBAL_DEF_BASIC("blazium/justamcp/disable_game_mcp", false);
-		const bool editor_enabled = _is_justamcp_editor_enabled();
-		const bool game_control = _is_justamcp_game_control_requested();
-		if (editor_enabled || game_control) {
+		GLOBAL_DEF_BASIC("blazium/justamcp/export_port", 0);
+		GLOBAL_DEF_BASIC("blazium/justamcp/project_mcp_dir", "res://mcp");
+		if (ProjectSettings::get_singleton()) {
+			ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::INT, "blazium/justamcp/export_port", PROPERTY_HINT_RANGE, "0,65535,1"));
+			ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "blazium/justamcp/project_mcp_dir", PROPERTY_HINT_DIR));
+		}
+		if (JustAMCPSettingsResolver::should_instantiate_runtime()) {
 			JustAMCPRuntime *runtime = memnew(JustAMCPRuntime);
 			Engine::get_singleton()->add_singleton(Engine::Singleton("JustAMCPRuntime", runtime));
-			if (game_control) {
-				runtime->set_enabled(true);
-			}
+			Engine::get_singleton()->add_singleton(Engine::Singleton("JustAMCP", runtime));
+			runtime->set_enabled(true);
 		}
 	}
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		GDREGISTER_CLASS(JustAMCPServer);
 		GDREGISTER_CLASS(JustAMCPToolExecutor);
 		GDREGISTER_CLASS(JustAMCPSceneTools);
 		GDREGISTER_CLASS(JustAMCPResourceTools);
@@ -345,6 +337,9 @@ void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 
 void uninitialize_justamcp_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		if (Engine::get_singleton()->has_singleton("JustAMCP")) {
+			Engine::get_singleton()->remove_singleton("JustAMCP");
+		}
 		if (Engine::get_singleton()->has_singleton("JustAMCPRuntime")) {
 			if (JustAMCPRuntime *runtime = Object::cast_to<JustAMCPRuntime>(Engine::get_singleton()->get_singleton_object("JustAMCPRuntime"))) {
 				Engine::get_singleton()->remove_singleton("JustAMCPRuntime");

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
@@ -523,6 +523,29 @@ void test_justamcp_http_modern_get_delete_and_listen() {
 	CHECK(get_legacy->get_status() != 405);
 }
 
+void test_justamcp_http_get_concatenated_modern_legacy_header() {
+	CHECK(MCPSessionManager::protocol_header_allows_legacy_sse("2025-11-25"));
+	CHECK(MCPSessionManager::protocol_header_allows_legacy_sse("2026-07-28, 2025-11-25"));
+	CHECK(MCPSessionManager::protocol_header_allows_legacy_sse("2025-11-25, 2026-07-28"));
+	CHECK(MCPSessionManager::protocol_header_allows_legacy_sse(String()));
+	CHECK(!MCPSessionManager::protocol_header_allows_legacy_sse(k_modern_protocol));
+
+	JustAMCPTestServerFixture fixture;
+	MCPSessionManager *session_manager = fixture.get_server().test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	const String session_id = _init_session(fixture.get_server(), session_manager, "2025-11-25");
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	Dictionary headers;
+	headers["Accept"] = "text/event-stream";
+	headers["MCP-Session-Id"] = session_id;
+	headers["MCP-Protocol-Version"] = "2026-07-28, 2025-11-25";
+	CHECK(session_manager->handle_mcp_get(_make_ctx("GET", headers), response));
+	CHECK(response->get_status() != 405);
+	CHECK(response->is_sse_response());
+}
+
 void test_justamcp_accepted_protocol_versions_pinning() {
 	ProjectSettings *ps = ProjectSettings::get_singleton();
 	TEST_FAIL_COND(ps == nullptr, "ProjectSettings is required");
@@ -614,6 +637,9 @@ void test_justamcp_http_initialize_modern_client_stays_legacy() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
 void test_justamcp_http_modern_get_delete_and_listen() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_get_concatenated_modern_legacy_header() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
 void test_justamcp_accepted_protocol_versions_pinning() {

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.h
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.h
@@ -45,6 +45,7 @@ void test_justamcp_http_modern_discover_and_list();
 void test_justamcp_http_modern_header_mismatch_and_unsupported();
 void test_justamcp_http_initialize_modern_client_stays_legacy();
 void test_justamcp_http_modern_get_delete_and_listen();
+void test_justamcp_http_get_concatenated_modern_legacy_header();
 void test_justamcp_accepted_protocol_versions_pinning();
 
 TEST_CASE("[Modules][JustAMCP] negotiate protocol versions") {
@@ -101,6 +102,10 @@ TEST_CASE("[Modules][JustAMCP] http initialize modern client stays legacy") {
 
 TEST_CASE("[Modules][JustAMCP] http modern get delete and listen") {
 	test_justamcp_http_modern_get_delete_and_listen();
+}
+
+TEST_CASE("[Modules][JustAMCP] http GET allows concatenated modern+legacy protocol header") {
+	test_justamcp_http_get_concatenated_modern_legacy_header();
 }
 
 TEST_CASE("[Modules][JustAMCP] accepted protocol versions pinning") {

--- a/modules/justamcp/tests/test_justamcp_runtime_export.cpp
+++ b/modules/justamcp/tests/test_justamcp_runtime_export.cpp
@@ -1,0 +1,358 @@
+/**************************************************************************/
+/*  test_justamcp_runtime_export.cpp                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_runtime_export.h"
+#include "../justamcp_cli_args.h"
+#include "../justamcp_json_rpc_transport.h"
+#include "../justamcp_project_registry.h"
+#include "../justamcp_runtime.h"
+#include "../justamcp_server.h"
+#include "../tools/justamcp_json_rpc_router.h"
+#include "../tools/justamcp_settings_resolver.h"
+#include "core/config/project_settings.h"
+#include "core/object/callable_method_pointer.h"
+#include "core/object/object.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_HTTPSERVER_ENABLED
+#include "modules/httpserver/http_response.h"
+#endif
+#include "tests/test_macros.h"
+
+class JustAMCPTestProjectHost : public Object {
+public:
+	String echo(const Dictionary &p_args) {
+		return String(p_args.get("text", ""));
+	}
+	String hello(const Dictionary &p_args) {
+		return "hello " + String(p_args.get("name", "world"));
+	}
+};
+
+static Vector<String> _args(const char *p_a, const char *p_b = nullptr, const char *p_c = nullptr) {
+	Vector<String> args;
+	args.push_back(p_a);
+	if (p_b) {
+		args.push_back(p_b);
+	}
+	if (p_c) {
+		args.push_back(p_c);
+	}
+	return args;
+}
+
+void test_justamcp_skip_autowork_unless_enable_mcp() {
+	CHECK(JustAMCPCliArgs::skip_mcp_server_for_args(_args("--aw-dir", ".")));
+	CHECK(!JustAMCPCliArgs::skip_mcp_server_for_args(_args("--aw-dir", ".", "--enable-mcp")));
+	CHECK(!JustAMCPCliArgs::skip_mcp_server_for_args(_args("--aw-dir", ".", "--enable-mcp-game-control")));
+	CHECK(JustAMCPCliArgs::skip_mcp_server_for_args(_args("--test")));
+	CHECK(JustAMCPCliArgs::skip_mcp_server_for_args(_args("--export-release")));
+	CHECK(!JustAMCPCliArgs::skip_mcp_server_for_args(Vector<String>()));
+}
+
+void test_justamcp_instantiate_gates() {
+	CHECK(!JustAMCPCliArgs::should_instantiate_editor_server_for(true, true));
+	CHECK(!JustAMCPCliArgs::should_instantiate_editor_server_for(false, false));
+	CHECK(JustAMCPCliArgs::should_instantiate_editor_server_for(false, true));
+	CHECK(!JustAMCPCliArgs::should_instantiate_runtime_for(true, true));
+	CHECK(!JustAMCPCliArgs::should_instantiate_runtime_for(false, false));
+	CHECK(JustAMCPCliArgs::should_instantiate_runtime_for(false, true));
+}
+
+void test_justamcp_runtime_port_is_editor_plus_one() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	CHECK(ps);
+	const int prev_port = int(ps->get_setting("blazium/justamcp/server_port", 6506));
+	const int prev_export = int(ps->get_setting("blazium/justamcp/export_port", 0));
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/server_port", 6506);
+	ps->set_setting("blazium/justamcp/export_port", 0);
+	JustAMCPCliArgs::clear_test_overrides();
+
+	CHECK(JustAMCPSettingsResolver::resolve_server_port() == 6506);
+	CHECK(JustAMCPSettingsResolver::resolve_runtime_port() == 6507);
+	CHECK(!JustAMCPSettingsResolver::runtime_port_conflicts_with_editor());
+
+	ps->set_setting("blazium/justamcp/export_port", 6600);
+	CHECK(JustAMCPSettingsResolver::resolve_runtime_port() == 6600);
+
+	JustAMCPCliArgs::set_test_mcp_port(6506);
+	CHECK(JustAMCPSettingsResolver::resolve_server_port() == 6506);
+	CHECK(JustAMCPSettingsResolver::resolve_runtime_port() == 6600);
+
+	JustAMCPCliArgs::set_test_mcp_game_port(6700);
+	CHECK(JustAMCPSettingsResolver::resolve_runtime_port() == 6700);
+
+	JustAMCPCliArgs::clear_test_overrides();
+	ps->set_setting("blazium/justamcp/export_port", 6506);
+	JustAMCPCliArgs::set_test_mcp_port(6506);
+	CHECK(JustAMCPSettingsResolver::runtime_port_conflicts_with_editor());
+
+	JustAMCPCliArgs::clear_test_overrides();
+	ps->set_setting("blazium/justamcp/server_port", prev_port);
+	ps->set_setting("blazium/justamcp/export_port", prev_export);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+}
+
+void test_justamcp_register_tool_in_tools_list() {
+	JustAMCPProjectRegistry::clear();
+	Dictionary schema;
+	schema["type"] = "object";
+	JustAMCPProjectRegistry::register_tool("proj_echo", "Echo a value", schema, Callable());
+
+	CHECK(JustAMCPProjectRegistry::has_tool("proj_echo"));
+	const Array listed = JustAMCPProjectRegistry::list_tool_schemas();
+	bool found = false;
+	for (int i = 0; i < listed.size(); i++) {
+		Dictionary tool = listed[i];
+		if (String(tool.get("name", "")) == "proj_echo") {
+			found = true;
+		}
+	}
+	CHECK(found);
+
+#ifdef TOOLS_ENABLED
+	Dictionary routed = JustAMCPJsonRpcRouter::route_tools_list("", 42);
+	CHECK(routed.has("result"));
+	Dictionary result = routed["result"];
+	Array tools = result.get("tools", Array());
+	bool listed_in_rpc = false;
+	for (int i = 0; i < tools.size(); i++) {
+		Dictionary tool = tools[i];
+		if (String(tool.get("name", "")) == "proj_echo") {
+			listed_in_rpc = true;
+		}
+	}
+	CHECK(listed_in_rpc);
+#endif
+
+	JustAMCPRuntime runtime;
+	CHECK(runtime.list_tools().size() >= 1);
+	CHECK(!runtime.is_listening());
+
+	JustAMCPProjectRegistry::clear();
+}
+
+void test_justamcp_runtime_host_list_is_project_only() {
+	JustAMCPProjectRegistry::clear();
+	Dictionary schema;
+	schema["type"] = "object";
+	JustAMCPProjectRegistry::register_tool("project_echo", "Echo a value", schema, Callable());
+	JustAMCPProjectRegistry::register_prompt("project_hello", "Greet", Callable());
+
+	const Array tools = JustAMCPProjectRegistry::list_tool_schemas();
+	CHECK(tools.size() == 1);
+	bool found_echo = false;
+	for (int i = 0; i < tools.size(); i++) {
+		const Dictionary tool = tools[i];
+		const String name = String(tool.get("name", ""));
+		CHECK(!name.begins_with("blazium_"));
+		if (name == "project_echo") {
+			found_echo = true;
+		}
+	}
+	CHECK(found_echo);
+
+	const Array prompts = JustAMCPProjectRegistry::list_prompt_schemas();
+	CHECK(prompts.size() == 1);
+	CHECK(String(Dictionary(prompts[0]).get("name", "")) == "project_hello");
+
+	Dictionary params;
+	params["protocolVersion"] = "2025-11-25";
+	Dictionary payload;
+	payload["params"] = params;
+	Dictionary routed = JustAMCPJsonRpcRouter::route_runtime_host_initialize(nullptr, payload, 1);
+	CHECK(routed.has("result"));
+	const Dictionary result = routed["result"];
+	const Dictionary capabilities = result.get("capabilities", Dictionary());
+	CHECK(capabilities.has("tools"));
+	CHECK(capabilities.has("prompts"));
+	CHECK(!capabilities.has("resources"));
+	CHECK(!capabilities.has("tasks"));
+	CHECK(String(Dictionary(result.get("serverInfo", Dictionary())).get("name", "")) == "blazium-game");
+
+	JustAMCPProjectRegistry::clear();
+}
+
+void test_justamcp_runtime_host_refuses_editor_port() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	CHECK(ps);
+	const int prev_port = int(ps->get_setting("blazium/justamcp/server_port", 6506));
+	const int prev_export = int(ps->get_setting("blazium/justamcp/export_port", 0));
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const bool prev_game = bool(ps->get_setting("blazium/justamcp/game_control_enabled", false));
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/server_port", 16506);
+	ps->set_setting("blazium/justamcp/export_port", 16506);
+	ps->set_setting("blazium/justamcp/game_control_enabled", true);
+	CHECK(JustAMCPSettingsResolver::runtime_port_conflicts_with_editor());
+
+	JustAMCPServer server;
+	server.set_runtime_host(true);
+	server.test_start_server();
+	CHECK(!server.is_server_started());
+
+	ps->set_setting("blazium/justamcp/server_port", prev_port);
+	ps->set_setting("blazium/justamcp/export_port", prev_export);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+	ps->set_setting("blazium/justamcp/game_control_enabled", prev_game);
+}
+
+void test_justamcp_project_mcp_name_and_dir_validation() {
+	CHECK(JustAMCPProjectRegistry::is_valid_entry_name("project_echo"));
+	CHECK(!JustAMCPProjectRegistry::is_valid_entry_name(""));
+	CHECK(!JustAMCPProjectRegistry::is_valid_entry_name(" project_echo"));
+	CHECK(!JustAMCPProjectRegistry::is_valid_entry_name("project echo"));
+	CHECK(!JustAMCPProjectRegistry::is_valid_entry_name("blazium_search_tools"));
+
+	CHECK(JustAMCPRuntime::is_valid_project_mcp_dir("res://mcp"));
+	CHECK(JustAMCPRuntime::is_valid_project_mcp_dir("res://"));
+	CHECK(!JustAMCPRuntime::is_valid_project_mcp_dir("user://mcp"));
+	CHECK(!JustAMCPRuntime::is_valid_project_mcp_dir("C:/mcp"));
+	CHECK(!JustAMCPRuntime::is_valid_project_mcp_dir("res://foo/../bar"));
+	CHECK(!JustAMCPRuntime::is_valid_project_mcp_dir("res://foo//bar"));
+
+	JustAMCPProjectRegistry::clear();
+	Dictionary schema;
+	schema["type"] = "object";
+	ERR_PRINT_OFF;
+	JustAMCPProjectRegistry::register_tool("blazium_spoof", "nope", schema, Callable());
+	JustAMCPProjectRegistry::register_prompt("bad name", "nope", Callable());
+	ERR_PRINT_ON;
+	CHECK(!JustAMCPProjectRegistry::has_tool("blazium_spoof"));
+	CHECK(!JustAMCPProjectRegistry::has_prompt("bad name"));
+	JustAMCPProjectRegistry::clear();
+}
+
+void test_justamcp_runtime_host_call_and_get() {
+	JustAMCPProjectRegistry::clear();
+	JustAMCPTestProjectHost *host = memnew(JustAMCPTestProjectHost);
+	Dictionary schema;
+	schema["type"] = "object";
+	JustAMCPProjectRegistry::register_tool("proj_echo", "Echo", schema, callable_mp(host, &JustAMCPTestProjectHost::echo));
+	JustAMCPProjectRegistry::register_prompt("proj_hello", "Greet", callable_mp(host, &JustAMCPTestProjectHost::hello));
+
+	Dictionary echo_args;
+	echo_args["text"] = "ping";
+	const Dictionary tool_call = JustAMCPProjectRegistry::call_tool_mcp("proj_echo", echo_args);
+	const Dictionary tool_result = tool_call.get("result", Dictionary());
+	CHECK(!bool(tool_result.get("isError", true)));
+	Array tool_content = tool_result.get("content", Array());
+	CHECK(tool_content.size() >= 1);
+	CHECK(String(Dictionary(tool_content[0]).get("text", "")) == "ping");
+
+	Dictionary hello_args;
+	hello_args["name"] = "cursor";
+	const Dictionary prompt_call = JustAMCPProjectRegistry::call_prompt("proj_hello", hello_args);
+	CHECK(bool(prompt_call.get("ok", false)));
+	Array messages = prompt_call.get("messages", Array());
+	CHECK(messages.size() >= 1);
+	Array content = Dictionary(messages[0]).get("content", Array());
+	CHECK(String(Dictionary(content[0]).get("text", "")) == "hello cursor");
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	JustAMCPServer server;
+	server.set_runtime_host(true);
+
+	Dictionary call_params;
+	call_params["name"] = "proj_echo";
+	call_params["arguments"] = echo_args;
+	Dictionary call_payload;
+	call_payload["jsonrpc"] = "2.0";
+	call_payload["id"] = 3;
+	call_payload["method"] = "tools/call";
+	call_payload["params"] = call_params;
+	const Dictionary call_rpc = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, call_payload, Ref<HTTPResponse>());
+	CHECK(call_rpc.has("result"));
+	CHECK(!call_rpc.has("error"));
+	Array rpc_content = Dictionary(call_rpc.get("result", Dictionary())).get("content", Array());
+	CHECK(String(Dictionary(rpc_content[0]).get("text", "")) == "ping");
+
+	Dictionary bad_call_params;
+	bad_call_params["name"] = "missing_tool";
+	Dictionary bad_call;
+	bad_call["jsonrpc"] = "2.0";
+	bad_call["id"] = 4;
+	bad_call["method"] = "tools/call";
+	bad_call["params"] = bad_call_params;
+	const Dictionary unknown_tool = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, bad_call, Ref<HTTPResponse>());
+	CHECK(unknown_tool.has("error"));
+
+	Dictionary missing_name;
+	missing_name["jsonrpc"] = "2.0";
+	missing_name["id"] = 5;
+	missing_name["method"] = "tools/call";
+	missing_name["params"] = Dictionary();
+	const Dictionary invalid_call = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, missing_name, Ref<HTTPResponse>());
+	CHECK(invalid_call.has("error"));
+
+	Dictionary get_params;
+	get_params["name"] = "proj_hello";
+	get_params["arguments"] = hello_args;
+	Dictionary get_payload;
+	get_payload["jsonrpc"] = "2.0";
+	get_payload["id"] = 6;
+	get_payload["method"] = "prompts/get";
+	get_payload["params"] = get_params;
+	const Dictionary get_rpc = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, get_payload, Ref<HTTPResponse>());
+	CHECK(get_rpc.has("result"));
+	Array get_messages = Dictionary(get_rpc.get("result", Dictionary())).get("messages", Array());
+	Array get_content = Dictionary(get_messages[0]).get("content", Array());
+	CHECK(String(Dictionary(get_content[0]).get("text", "")) == "hello cursor");
+
+	Dictionary unknown_prompt_params;
+	unknown_prompt_params["name"] = "missing_prompt";
+	Dictionary unknown_prompt;
+	unknown_prompt["jsonrpc"] = "2.0";
+	unknown_prompt["id"] = 7;
+	unknown_prompt["method"] = "prompts/get";
+	unknown_prompt["params"] = unknown_prompt_params;
+	CHECK(JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, unknown_prompt, Ref<HTTPResponse>()).has("error"));
+#endif
+
+	JustAMCPProjectRegistry::clear();
+	memdelete(host);
+}
+
+void test_justamcp_invalid_ports_are_rejected() {
+	CHECK(JustAMCPCliArgs::is_valid_port(6506));
+	CHECK(JustAMCPCliArgs::is_valid_port(1));
+	CHECK(JustAMCPCliArgs::is_valid_port(65535));
+	CHECK(!JustAMCPCliArgs::is_valid_port(0));
+	CHECK(!JustAMCPCliArgs::is_valid_port(65536));
+	CHECK(!JustAMCPCliArgs::is_valid_port(-1));
+
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	CHECK(ps);
+	const int prev_port = int(ps->get_setting("blazium/justamcp/server_port", 6506));
+	const int prev_export = int(ps->get_setting("blazium/justamcp/export_port", 0));
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/server_port", 70000);
+	ps->set_setting("blazium/justamcp/export_port", 70001);
+	JustAMCPCliArgs::clear_test_overrides();
+	CHECK(JustAMCPSettingsResolver::resolve_server_port() == 6506);
+	CHECK(JustAMCPSettingsResolver::resolve_runtime_port() == 6507);
+
+	JustAMCPCliArgs::set_test_mcp_port(70000);
+	CHECK(JustAMCPCliArgs::mcp_port() == -1);
+	JustAMCPCliArgs::set_test_mcp_game_port(0);
+	CHECK(JustAMCPCliArgs::mcp_game_port() == -1);
+	JustAMCPCliArgs::clear_test_overrides();
+
+	ps->set_setting("blazium/justamcp/server_port", prev_port);
+	ps->set_setting("blazium/justamcp/export_port", prev_export);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+}
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_runtime_export.h
+++ b/modules/justamcp/tests/test_justamcp_runtime_export.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  test_justamcp_runtime_export.h                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#pragma once
+
+#include "tests/test_macros.h"
+
+void test_justamcp_skip_autowork_unless_enable_mcp();
+void test_justamcp_instantiate_gates();
+void test_justamcp_runtime_port_is_editor_plus_one();
+void test_justamcp_register_tool_in_tools_list();
+void test_justamcp_runtime_host_list_is_project_only();
+void test_justamcp_runtime_host_refuses_editor_port();
+void test_justamcp_project_mcp_name_and_dir_validation();
+void test_justamcp_runtime_host_call_and_get();
+void test_justamcp_invalid_ports_are_rejected();
+
+TEST_CASE("[Modules][JustAMCP] Autowork skips MCP unless --enable-mcp") {
+	test_justamcp_skip_autowork_unless_enable_mcp();
+}
+
+TEST_CASE("[Modules][JustAMCP] instantiate gates") {
+	test_justamcp_instantiate_gates();
+}
+
+TEST_CASE("[Modules][JustAMCP] game port is editor plus one") {
+	test_justamcp_runtime_port_is_editor_plus_one();
+}
+
+TEST_CASE("[Modules][JustAMCP] register_tool appears in tools/list") {
+	test_justamcp_register_tool_in_tools_list();
+}
+
+TEST_CASE("[Modules][JustAMCP] runtime-host list is project tools only") {
+	test_justamcp_runtime_host_list_is_project_only();
+}
+
+TEST_CASE("[Modules][JustAMCP] runtime host refuses editor port") {
+	test_justamcp_runtime_host_refuses_editor_port();
+}
+
+TEST_CASE("[Modules][JustAMCP] project MCP name and dir validation") {
+	test_justamcp_project_mcp_name_and_dir_validation();
+}
+
+TEST_CASE("[Modules][JustAMCP] runtime-host tools/call and prompts/get") {
+	test_justamcp_runtime_host_call_and_get();
+}
+
+TEST_CASE("[Modules][JustAMCP] invalid MCP ports are rejected") {
+	test_justamcp_invalid_ports_are_rejected();
+}

--- a/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
@@ -29,8 +29,10 @@
 
 #include "justamcp_json_rpc_helpers.h"
 
-#ifdef TOOLS_ENABLED
 #include "../justamcp_mcp_spec.h"
+#include "core/io/json.h"
+
+#ifdef TOOLS_ENABLED
 #include "justamcp_tool_schema_cache.h"
 #endif
 
@@ -90,12 +92,6 @@ String JustAMCPJsonRpcHelpers::get_tool_task_support(const String &p_tool_name) 
 #endif
 	return "forbidden";
 }
-
-#ifdef TOOLS_ENABLED
-
-#include "core/io/json.h"
-
-static bool mcp_tool_settings_dirty = false;
 
 Dictionary JustAMCPJsonRpcHelpers::format_tool_result(bool p_success, const Variant &p_result, const String &p_error) {
 	Dictionary rpc_result;
@@ -201,6 +197,10 @@ Dictionary JustAMCPJsonRpcHelpers::format_tool_result(bool p_success, const Vari
 	}
 	return rpc_result;
 }
+
+#ifdef TOOLS_ENABLED
+
+static bool mcp_tool_settings_dirty = false;
 
 void JustAMCPJsonRpcHelpers::mark_mcp_tool_settings_dirty() {
 	mcp_tool_settings_dirty = true;

--- a/modules/justamcp/tools/justamcp_json_rpc_helpers.h
+++ b/modules/justamcp/tools/justamcp_json_rpc_helpers.h
@@ -39,9 +39,9 @@ public:
 	static Dictionary extract_request_meta(const Dictionary &p_params);
 	static String progress_token_from_meta(const Dictionary &p_meta);
 	static String get_tool_task_support(const String &p_tool_name);
+	static Dictionary format_tool_result(bool p_success, const Variant &p_result, const String &p_error = String());
 
 #ifdef TOOLS_ENABLED
-	static Dictionary format_tool_result(bool p_success, const Variant &p_result, const String &p_error = String());
 	static bool should_broadcast_tools_list_changed();
 	static void mark_mcp_tool_settings_dirty();
 #endif

--- a/modules/justamcp/tools/justamcp_json_rpc_router.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_router.cpp
@@ -33,79 +33,18 @@
 
 #include "../justamcp_log_levels.h"
 #include "../justamcp_mcp_spec.h"
+#include "../justamcp_pagination.h"
+#include "../justamcp_project_registry.h"
 #include "../justamcp_server.h"
 #include "../justamcp_session_manager.h"
 #include "justamcp_prompt_executor.h"
 #include "justamcp_resource_executor.h"
 #include "justamcp_task_manager.h"
 #include "justamcp_tool_executor.h"
+#include "justamcp_tool_schema_cache.h"
+#include "justamcp_toolset_registry.h"
 
 #include "core/os/mutex.h"
-
-String JustAMCPJsonRpcRouter::extract_list_cursor(const Dictionary &p_payload) {
-	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
-		return String();
-	}
-	const Dictionary params = p_payload["params"];
-	if (!params.has("cursor")) {
-		return String();
-	}
-	return String(params["cursor"]);
-}
-
-Dictionary JustAMCPJsonRpcRouter::finalize_list_result(const Dictionary &p_result, const Variant &p_req_id) {
-	if (p_result.has("ok") && !bool(p_result.get("ok", true))) {
-		Dictionary err;
-		err["handled"] = true;
-		err["jsonrpc"] = "2.0";
-		err["id"] = p_req_id;
-		Dictionary error_dict;
-		error_dict["code"] = p_result.get("error_code", -32602);
-		error_dict["message"] = p_result.get("error", "Invalid params.");
-		err["error"] = error_dict;
-		return err;
-	}
-
-	Dictionary out = p_result.duplicate();
-	out.erase("ok");
-	justamcp_apply_protocol_to_list_result(out, justamcp_active_protocol_version());
-	Dictionary rpc_result;
-	rpc_result["handled"] = true;
-	rpc_result["jsonrpc"] = "2.0";
-	rpc_result["id"] = p_req_id;
-	rpc_result["result"] = out;
-	return rpc_result;
-}
-
-Dictionary JustAMCPJsonRpcRouter::make_invalid_params(const Variant &p_req_id, const String &p_message) {
-	Dictionary err;
-	err["handled"] = true;
-	err["jsonrpc"] = "2.0";
-	err["id"] = p_req_id;
-	Dictionary error_dict;
-	error_dict["code"] = -32602;
-	error_dict["message"] = p_message;
-	err["error"] = error_dict;
-	return err;
-}
-
-Dictionary JustAMCPJsonRpcRouter::finalize_action_result(const Dictionary &p_result, const Variant &p_req_id) {
-	Dictionary rpc_result;
-	rpc_result["handled"] = true;
-	rpc_result["jsonrpc"] = "2.0";
-	rpc_result["id"] = p_req_id;
-	if (p_result.get("ok", false)) {
-		Dictionary out = p_result.duplicate();
-		out.erase("ok");
-		rpc_result["result"] = out;
-	} else {
-		Dictionary error_dict;
-		error_dict["code"] = p_result.get("error_code", -32603);
-		error_dict["message"] = p_result.get("error", "Request failed.");
-		rpc_result["error"] = error_dict;
-	}
-	return rpc_result;
-}
 
 static Dictionary _handle_resource_subscription(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var) {
 	Dictionary empty;
@@ -284,18 +223,35 @@ Dictionary JustAMCPJsonRpcRouter::route(const String &p_method, const Dictionary
 }
 
 Dictionary JustAMCPJsonRpcRouter::route_tools_list(const String &p_cursor, const Variant &p_req_id_var) {
-	Dictionary result = JustAMCPToolExecutor::list_tools(p_cursor);
-	return finalize_list_result(result, p_req_id_var);
+	bool apply_discovery_filter = false;
+	if (JustAMCPToolsetRegistry::get_singleton() && JustAMCPToolsetRegistry::get_singleton()->is_discovery_enabled()) {
+		apply_discovery_filter = true;
+	}
+	Array schemas = JustAMCPToolSchemaCache::get_schemas(false, false, apply_discovery_filter, false);
+	const Array project_tools = JustAMCPProjectRegistry::list_tool_schemas();
+	for (int i = 0; i < project_tools.size(); i++) {
+		schemas.push_back(project_tools[i]);
+	}
+	return finalize_list_result(justamcp_pagination_slice_array(schemas, p_cursor, "tools"), p_req_id_var);
 }
 
 Dictionary JustAMCPJsonRpcRouter::route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts) {
+	Dictionary listed;
 	if (p_prompts) {
-		return finalize_list_result(p_prompts->list_prompts(p_cursor), p_req_id_var);
+		listed = p_prompts->list_prompts(p_cursor);
+	} else {
+		listed["ok"] = true;
+		listed["prompts"] = Array();
 	}
-	Dictionary empty;
-	empty["ok"] = true;
-	empty["prompts"] = Array();
-	return finalize_list_result(empty, p_req_id_var);
+	if (p_cursor.is_empty()) {
+		Array prompts = listed.get("prompts", Array());
+		const Array project_prompts = JustAMCPProjectRegistry::list_prompt_schemas();
+		for (int i = 0; i < project_prompts.size(); i++) {
+			prompts.push_back(project_prompts[i]);
+		}
+		listed["prompts"] = prompts;
+	}
+	return finalize_list_result(listed, p_req_id_var);
 }
 
 Dictionary JustAMCPJsonRpcRouter::route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts) {
@@ -308,6 +264,9 @@ Dictionary JustAMCPJsonRpcRouter::route_prompts_get(const Dictionary &p_payload,
 	}
 	const String prompt_name = params["name"];
 	const Dictionary args = params.has("arguments") && params["arguments"].get_type() == Variant::DICTIONARY ? Dictionary(params["arguments"]) : Dictionary();
+	if (JustAMCPProjectRegistry::has_prompt(prompt_name)) {
+		return finalize_action_result(JustAMCPProjectRegistry::call_prompt(prompt_name, args), p_req_id_var);
+	}
 	Dictionary result;
 	if (p_prompts) {
 		result = p_prompts->get_prompt(prompt_name, args);

--- a/modules/justamcp/tools/justamcp_json_rpc_router.h
+++ b/modules/justamcp/tools/justamcp_json_rpc_router.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
@@ -45,6 +43,8 @@ public:
 	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
 	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
 	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
+	static Dictionary route_runtime_host_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id);
+#ifdef TOOLS_ENABLED
 	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
 	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
 	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
@@ -56,6 +56,5 @@ public:
 	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
 	static Dictionary route_tasks_update(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
 	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-};
-
 #endif
+};

--- a/modules/justamcp/tools/justamcp_settings_resolver.cpp
+++ b/modules/justamcp/tools/justamcp_settings_resolver.cpp
@@ -30,6 +30,7 @@
 #include "justamcp_settings_resolver.h"
 
 #include "../justamcp_cli_args.h"
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 
 #ifdef TOOLS_ENABLED
@@ -146,10 +147,30 @@ void JustAMCPSettingsResolver::set_array(const String &p_path, const Array &p_va
 
 int JustAMCPSettingsResolver::resolve_server_port() {
 	const int cli_port = JustAMCPCliArgs::mcp_port();
-	if (cli_port > 0) {
+	if (JustAMCPCliArgs::is_valid_port(cli_port)) {
 		return cli_port;
 	}
-	return resolve_int("blazium/justamcp/server_port", 6506);
+	const int port = resolve_int("blazium/justamcp/server_port", 6506);
+	if (JustAMCPCliArgs::is_valid_port(port)) {
+		return port;
+	}
+	return 6506;
+}
+
+int JustAMCPSettingsResolver::resolve_runtime_port() {
+	const int cli_port = JustAMCPCliArgs::mcp_game_port();
+	if (JustAMCPCliArgs::is_valid_port(cli_port)) {
+		return cli_port;
+	}
+	const int export_port = resolve_int("blazium/justamcp/export_port", 0);
+	if (JustAMCPCliArgs::is_valid_port(export_port)) {
+		return export_port;
+	}
+	const int editor_port = resolve_server_port();
+	if (!JustAMCPCliArgs::is_valid_port(editor_port) || editor_port >= 65535) {
+		return 6507;
+	}
+	return editor_port + 1;
 }
 
 bool JustAMCPSettingsResolver::resolve_server_enabled() {
@@ -157,6 +178,38 @@ bool JustAMCPSettingsResolver::resolve_server_enabled() {
 		return true;
 	}
 	return resolve_bool("blazium/justamcp/server_enabled", false);
+}
+
+bool JustAMCPSettingsResolver::resolve_runtime_enabled() {
+	if (JustAMCPCliArgs::disable_game_mcp() || resolve_bool("blazium/justamcp/disable_game_mcp", false)) {
+		return false;
+	}
+	if (JustAMCPCliArgs::enable_mcp_game_control()) {
+		return true;
+	}
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		return resolve_bool("blazium/justamcp/game_control_enabled", false);
+	}
+#endif
+	if (JustAMCPCliArgs::enable_mcp()) {
+		return true;
+	}
+	return resolve_bool("blazium/justamcp/game_control_enabled", false);
+}
+
+bool JustAMCPSettingsResolver::should_instantiate_editor_server() {
+	return JustAMCPCliArgs::should_instantiate_editor_server_for(JustAMCPCliArgs::skip_mcp_server(), resolve_server_enabled());
+}
+
+bool JustAMCPSettingsResolver::should_instantiate_runtime() {
+	return JustAMCPCliArgs::should_instantiate_runtime_for(JustAMCPCliArgs::skip_mcp_server(), resolve_runtime_enabled());
+}
+
+bool JustAMCPSettingsResolver::runtime_port_conflicts_with_editor() {
+	const int editor_port = resolve_server_port();
+	const int game_port = resolve_runtime_port();
+	return editor_port > 0 && game_port > 0 && editor_port == game_port;
 }
 
 #ifdef TOOLS_ENABLED

--- a/modules/justamcp/tools/justamcp_settings_resolver.h
+++ b/modules/justamcp/tools/justamcp_settings_resolver.h
@@ -42,7 +42,12 @@ public:
 	static void set_array(const String &p_path, const Array &p_value);
 
 	static int resolve_server_port();
+	static int resolve_runtime_port();
 	static bool resolve_server_enabled();
+	static bool resolve_runtime_enabled();
+	static bool should_instantiate_editor_server();
+	static bool should_instantiate_runtime();
+	static bool runtime_port_conflicts_with_editor();
 
 #ifdef TOOLS_ENABLED
 	static void set_category_default(const String &p_category, bool p_is_core);


### PR DESCRIPTION
## Summary
- Autowork --aw-*, --test, and --export* skip MCP unless --enable-mcp or --enable-mcp-game-control is also on the command line. The editor server and game runtime are not constructed when disabled.
- Game HTTP MCP listens on export_port or editor port + 1 (6506 to 6507) and refuses to bind the editor port. Cursor snippets now include blazium-game on that port.
- Templates can build JustAMCP as a Streamable HTTP host. Projects register tools/prompts from res://mcp/register.gd or register.luau via JustAMCPRuntime.register_tool.

## Test plan
- [x] python -m SCons platform=windows target=editor tests=yes arch=x86_64 -j8
- [x] --headless --test --test-case=*[JustAMCP]* (319 passed)
- [ ] Editor MCP on http://127.0.0.1:6506/mcp (tools/list)
- [ ] Play/export with game MCP on http://127.0.0.1:6507/mcp (blazium-game); editor must not answer that port
- [ ] Autowork --aw-dir without --enable-mcp prints no JustAMCP listen line