### PR TITLE
Add games_enet_webrtc module for ENet over WebRTC

### DIFF
--- a/modules/games_enet_webrtc/SCsub
+++ b/modules/games_enet_webrtc/SCsub
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_gew = env_modules.Clone()
+env_gew.Prepend(CPPPATH=["#thirdparty/enet"])
+
+module_obj = []
+env_gew.add_source_files(module_obj, "*.cpp")
+
+if env["tests"]:
+    env_gew.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_gew.add_source_files(module_obj, "tests/test_games_enet_webrtc.cpp")
+    if env["disable_exceptions"]:
+        env_gew.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
+
+env.modules_sources += module_obj

--- a/modules/games_enet_webrtc/config.py
+++ b/modules/games_enet_webrtc/config.py
@@ -1,0 +1,22 @@
+def can_build(env, platform):
+    env.module_add_dependencies("games_enet_webrtc", ["enet", "webrtc", "websocket"])
+    return True
+
+
+def configure(env):
+    pass
+
+
+def is_enabled():
+    return True
+
+
+def get_doc_classes():
+    return [
+        "WebRTCEnetSession",
+        "SignalClient",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/games_enet_webrtc/config.py
+++ b/modules/games_enet_webrtc/config.py
@@ -8,7 +8,8 @@ def configure(env):
 
 
 def is_enabled():
-    return True
+    # Disabled by default. Enable with: module_games_enet_webrtc_enabled=yes
+    return False
 
 
 def get_doc_classes():

--- a/modules/games_enet_webrtc/doc_classes/SignalClient.xml
+++ b/modules/games_enet_webrtc/doc_classes/SignalClient.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SignalClient" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		WebSocket client for the Blazium lobby and signaling protocol.
+	</brief_description>
+	<description>
+		Speaks protocol v1 JSON envelopes to an example [code]blazium-signal[/code] service: rooms, SDP/ICE, fake addresses, and last-resort datagram relay. [WebRTCEnetSession] owns one of these. Game code can also use it to build other utilities against the same contract.
+		This client never talks to TURN's internal session API.
+	</description>
+	<tutorials>
+		<link title="games_enet_webrtc Module Tests">https://github.com/blazium-games/games_enet_webrtc_module_tests</link>
+		<link title="Example signaling service">https://github.com/blazium-games/blazium-signal</link>
+		<link title="Example TURN service">https://github.com/blazium-games/blazium-turn</link>
+	</tutorials>
+	<methods>
+		<method name="close">
+			<return type="void" />
+			<description>
+				Closes the signaling WebSocket.
+			</description>
+		</method>
+		<method name="configure">
+			<return type="int" enum="Error" />
+			<param index="0" name="url" type="String" />
+			<param index="1" name="game_id" type="String" />
+			<param index="2" name="auth_token" type="String" />
+			<description>
+				Sets [code]ws://[/code] or [code]wss://[/code] URL, game namespace, and optional bearer token.
+			</description>
+		</method>
+		<method name="connect_to_signal">
+			<return type="int" enum="Error" />
+			<description>
+				Opens the WebSocket. Sends [code]X-Game-Id[/code] and optional [code]Authorization[/code] headers.
+			</description>
+		</method>
+		<method name="is_open" qualifiers="const">
+			<return type="bool" />
+			<description>
+				True when the signaling WebSocket is open.
+			</description>
+		</method>
+		<method name="poll">
+			<return type="void" />
+			<description>
+				Must be called regularly. [WebRTCEnetSession] does this from [method Node._process].
+			</description>
+		</method>
+		<method name="send_message">
+			<return type="int" enum="Error" />
+			<param index="0" name="type" type="int" />
+			<param index="1" name="data" type="Dictionary" />
+			<param index="2" name="id" type="int" default="0" />
+			<description>
+				Sends a protocol v1 envelope [code]{ "v": 1, "type": type, "id": id, "data": data }[/code].
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="connected">
+			<description>
+				The signaling WebSocket is open.
+			</description>
+		</signal>
+		<signal name="disconnected">
+			<description>
+				The signaling WebSocket closed after having been open.
+			</description>
+		</signal>
+		<signal name="message_received">
+			<param index="0" name="type" type="int" />
+			<param index="1" name="id" type="int" />
+			<param index="2" name="data" type="Dictionary" />
+			<description>
+				A parsed protocol envelope from the server.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/games_enet_webrtc/doc_classes/WebRTCEnetSession.xml
+++ b/modules/games_enet_webrtc/doc_classes/WebRTCEnetSession.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="WebRTCEnetSession" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Coordinates a Blazium lobby session that carries ENet over WebRTC DataChannels.
+	</brief_description>
+	<description>
+		[WebRTCEnetSession] talks only to an example signaling service (see [SignalClient]). It assigns fake addresses in [code]10.66.0.0/16[/code], installs a per-host ENet socket backend, and returns a normal [ENetMultiplayerPeer] for RPCs and scene replication.
+		Add this node to the tree so it can poll. LAN [ENetMultiplayerPeer] games that never construct a session keep UDP.
+		Native DataChannels need a [WebRTCPeerConnection] backend (webrtc-native on desktop). The WSS relay path still works without it; call [method set_force_relay] from tests.
+	</description>
+	<tutorials>
+		<link title="games_enet_webrtc Module Tests">https://github.com/blazium-games/games_enet_webrtc_module_tests</link>
+		<link title="Example signaling service">https://github.com/blazium-games/blazium-signal</link>
+		<link title="Example TURN service">https://github.com/blazium-games/blazium-turn</link>
+	</tutorials>
+	<methods>
+		<method name="close">
+			<return type="void" />
+			<description>
+				Sends LEAVE if the signaling socket is still open, then tears down links, the ENet peer, and the socket. Does not affect other ENet hosts in this process.
+			</description>
+		</method>
+		<method name="configure">
+			<return type="int" enum="Error" />
+			<param index="0" name="signal_url" type="String" />
+			<param index="1" name="game_id" type="String" />
+			<param index="2" name="auth_token" type="String" />
+			<description>
+				Sets the signaling WebSocket URL ([code]ws://[/code] or [code]wss://[/code]), game namespace ([code]A-Za-z0-9._-[/code]), and optional bearer token. Rejects CR/LF in any field. Open example servers accept an empty token.
+			</description>
+		</method>
+		<method name="create_room">
+			<return type="Signal" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="max_clients" type="int" default="8" />
+			<param index="2" name="password" type="String" default="&quot;&quot;" />
+			<param index="3" name="hidden" type="bool" default="false" />
+			<param index="4" name="tags" type="PackedStringArray" default="PackedStringArray()" />
+			<description>
+				Starts an async host flow. Await the returned [signal session_ready] signal, then assign [method get_peer] to [member MultiplayerAPI.multiplayer_peer].
+			</description>
+		</method>
+		<method name="get_force_relay" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether WSS relay is forced.
+			</description>
+		</method>
+		<method name="get_ice_timeout_msec" qualifiers="const">
+			<return type="int" />
+			<description>
+				Current ICE timeout in milliseconds.
+			</description>
+		</method>
+		<method name="get_local_fake_ip" qualifiers="const">
+			<return type="String" />
+			<description>
+				Logical address in [code]10.66.0.0/16[/code]. Host is [code]10.66.0.1[/code].
+			</description>
+		</method>
+		<method name="get_local_fake_port" qualifiers="const">
+			<return type="int" />
+			<description>
+				Logical ENet port (always 1 in v1).
+			</description>
+		</method>
+		<method name="get_local_signal_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Signaling id. Host is always 1.
+			</description>
+		</method>
+		<method name="get_peer" qualifiers="const">
+			<return type="ENetMultiplayerPeer" />
+			<description>
+				The ENet peer created after [signal session_ready]. Null before the session is ready.
+			</description>
+		</method>
+		<method name="get_room_code" qualifiers="const">
+			<return type="String" />
+			<description>
+				Short room code assigned by the signaling service.
+			</description>
+		</method>
+		<method name="is_in_room" qualifiers="const">
+			<return type="bool" />
+			<description>
+				True after [signal session_ready] until [method close] or [method leave].
+			</description>
+		</method>
+		<method name="join_room">
+			<return type="Signal" />
+			<param index="0" name="room_code" type="String" />
+			<param index="1" name="password" type="String" default="&quot;&quot;" />
+			<param index="2" name="display_name" type="String" default="&quot;&quot;" />
+			<description>
+				Starts an async joiner flow. Optional [param display_name] is stripped of controls and ignored if empty or invalid. Does not create the ENet client until the host DataChannel (or relay) is ready.
+			</description>
+		</method>
+		<method name="kick">
+			<return type="int" enum="Error" />
+			<param index="0" name="signal_id" type="int" />
+			<description>
+				Host-only. Drops [param signal_id] from the room. [param signal_id] must be 1–254, in the room, and not the host.
+			</description>
+		</method>
+		<method name="leave">
+			<return type="int" enum="Error" />
+			<description>
+				Sends LEAVE and tears the session down. Safe to call when not in a room.
+			</description>
+		</method>
+		<method name="list_rooms">
+			<return type="Signal" />
+			<description>
+				Requests visible rooms for the configured [code]game_id[/code]. Await [signal rooms_listed].
+			</description>
+		</method>
+		<method name="seal">
+			<return type="int" enum="Error" />
+			<description>
+				Host-only. Stops new joins. Existing members stay.
+			</description>
+		</method>
+		<method name="set_force_relay">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Skip ICE and send ENet datagrams on the signaling WebSocket. For tests and environments without a native WebRTC backend.
+			</description>
+		</method>
+		<method name="set_ice_timeout_msec">
+			<return type="void" />
+			<param index="0" name="msec" type="int" />
+			<description>
+				Milliseconds to wait for a DataChannel before switching a pair onto WSS relay. Default 8000.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="failed">
+			<param index="0" name="reason" type="String" />
+			<description>
+				The session could not start or the signaling service returned an error.
+			</description>
+		</signal>
+		<signal name="peer_link_down">
+			<param index="0" name="fake_ip" type="String" />
+			<param index="1" name="fake_port" type="int" />
+			<param index="2" name="signal_id" type="int" />
+			<description>
+				A remote peer left the room.
+			</description>
+		</signal>
+		<signal name="peer_link_up">
+			<param index="0" name="fake_ip" type="String" />
+			<param index="1" name="fake_port" type="int" />
+			<param index="2" name="signal_id" type="int" />
+			<description>
+				A remote peer's DataChannel or relay path is ready.
+			</description>
+		</signal>
+		<signal name="rooms_listed">
+			<param index="0" name="rooms" type="Array" />
+			<description>
+				Visible rooms for this [code]game_id[/code].
+			</description>
+		</signal>
+		<signal name="session_ready">
+			<param index="0" name="local_fake_ip" type="String" />
+			<param index="1" name="local_fake_port" type="int" />
+			<param index="2" name="room_code" type="String" />
+			<description>
+				Emitted when the ENet peer is created and transport is ready.
+			</description>
+		</signal>
+		<signal name="using_relay">
+			<param index="0" name="signal_id" type="int" />
+			<description>
+				The pair fell back to the signaling WSS datagram relay.
+			</description>
+		</signal>
+		<signal name="using_turn">
+			<param index="0" name="signal_id" type="int" />
+			<description>
+				ICE selected a TURN relay candidate. This is not a failure.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/games_enet_webrtc/enet_webrtc_socket.cpp
+++ b/modules/games_enet_webrtc/enet_webrtc_socket.cpp
@@ -1,0 +1,112 @@
+/**************************************************************************/
+/*  enet_webrtc_socket.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "enet_webrtc_socket.h"
+#include "webrtc_enet_session.h"
+
+#include "fake_address_map.h"
+#include "protocol.h"
+
+#include <cstring>
+
+ENetWebRTCSocket::ENetWebRTCSocket(FakeAddressMap *p_map, WebRTCEnetSession *p_session) :
+		map(p_map),
+		session(p_session) {
+}
+
+Error ENetWebRTCSocket::bind(IPAddress p_ip, uint16_t p_port) {
+	bound_ip = p_ip;
+	bound_port = p_port;
+	bound = true;
+	return OK;
+}
+
+Error ENetWebRTCSocket::get_socket_address(IPAddress *r_ip, uint16_t *r_port) {
+	if (!bound) {
+		return ERR_UNCONFIGURED;
+	}
+	if (r_ip) {
+		*r_ip = bound_ip;
+	}
+	if (r_port) {
+		*r_port = bound_port;
+	}
+	return OK;
+}
+
+Error ENetWebRTCSocket::sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IPAddress p_ip, uint16_t p_port) {
+	r_sent = 0;
+	ERR_FAIL_NULL_V(session, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(p_buffer == nullptr || p_len <= 0 || p_len > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES, ERR_INVALID_PARAMETER);
+	const Error err = session->send_datagram(p_ip, p_port, p_buffer, p_len);
+	if (err != OK) {
+		return err;
+	}
+	r_sent = p_len;
+	return OK;
+}
+
+Error ENetWebRTCSocket::recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddress &r_ip, uint16_t &r_port) {
+	r_read = 0;
+	ERR_FAIL_NULL_V(map, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(p_buffer == nullptr || p_len <= 0, ERR_INVALID_PARAMETER);
+	InboundDatagram d;
+	if (!map->pop_inbound(d)) {
+		return ERR_BUSY;
+	}
+	const int copy = MIN(p_len, d.data.size());
+	if (copy > 0) {
+		memcpy(p_buffer, d.data.ptr(), copy);
+	}
+	r_read = copy;
+	r_ip = d.src_ip;
+	r_port = d.src_port;
+	if (d.data.size() > p_len) {
+		return ERR_OUT_OF_MEMORY;
+	}
+	return OK;
+}
+
+int ENetWebRTCSocket::set_option(int p_option, int p_value) {
+	(void)p_value;
+	switch (p_option) {
+		case ENET_SOCKOPT_NONBLOCK:
+		case ENET_SOCKOPT_RCVBUF:
+		case ENET_SOCKOPT_SNDBUF:
+			return 0;
+		default:
+			return 0;
+	}
+}
+
+void ENetWebRTCSocket::close() {
+	bound = false;
+	bound_ip.clear();
+	bound_port = 0;
+}

--- a/modules/games_enet_webrtc/enet_webrtc_socket.h
+++ b/modules/games_enet_webrtc/enet_webrtc_socket.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  enet_webrtc_socket.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "enet/enet_godot_socket.h"
+
+class FakeAddressMap;
+class WebRTCEnetSession;
+
+class ENetWebRTCSocket : public ENetGodotSocket {
+	FakeAddressMap *map = nullptr;
+	WebRTCEnetSession *session = nullptr;
+	IPAddress bound_ip;
+	uint16_t bound_port = 0;
+	bool bound = false;
+
+public:
+	ENetWebRTCSocket(FakeAddressMap *p_map, WebRTCEnetSession *p_session);
+
+	Error bind(IPAddress p_ip, uint16_t p_port) override;
+	Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) override;
+	Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IPAddress p_ip, uint16_t p_port) override;
+	Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddress &r_ip, uint16_t &r_port) override;
+	int set_option(int p_option, int p_value) override;
+	void close() override;
+	bool can_upgrade() override { return false; }
+};

--- a/modules/games_enet_webrtc/enet_webrtc_socket_factory.cpp
+++ b/modules/games_enet_webrtc/enet_webrtc_socket_factory.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  enet_webrtc_socket_factory.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "enet_webrtc_socket_factory.h"
+#include "enet_webrtc_socket.h"
+#include "webrtc_enet_session.h"
+
+thread_local FakeAddressMap *ENetWebRTCSocketFactory::map = nullptr;
+thread_local WebRTCEnetSession *ENetWebRTCSocketFactory::session = nullptr;
+
+ENetGodotSocket *ENetWebRTCSocketFactory::_create() {
+	if (!map || !session) {
+		return nullptr;
+	}
+	return memnew(ENetWebRTCSocket(map, session));
+}
+
+void ENetWebRTCSocketFactory::install(FakeAddressMap *p_map, WebRTCEnetSession *p_session) {
+	map = p_map;
+	session = p_session;
+	enet_set_socket_create_fn(&_create);
+}
+
+void ENetWebRTCSocketFactory::uninstall() {
+	enet_set_socket_create_fn(nullptr);
+	map = nullptr;
+	session = nullptr;
+}
+
+ENetWebRTCSocketFactory::Guard::Guard(FakeAddressMap *p_map, WebRTCEnetSession *p_session) {
+	ENetWebRTCSocketFactory::install(p_map, p_session);
+}
+
+ENetWebRTCSocketFactory::Guard::~Guard() {
+	ENetWebRTCSocketFactory::uninstall();
+}

--- a/modules/games_enet_webrtc/enet_webrtc_socket_factory.h
+++ b/modules/games_enet_webrtc/enet_webrtc_socket_factory.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  enet_webrtc_socket_factory.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "enet/enet_godot_socket.h"
+
+class FakeAddressMap;
+class WebRTCEnetSession;
+
+class ENetWebRTCSocketFactory {
+	static thread_local FakeAddressMap *map;
+	static thread_local WebRTCEnetSession *session;
+
+	static ENetGodotSocket *_create();
+
+public:
+	class Guard {
+	public:
+		Guard(FakeAddressMap *p_map, WebRTCEnetSession *p_session);
+		~Guard();
+	};
+
+	static void install(FakeAddressMap *p_map, WebRTCEnetSession *p_session);
+	static void uninstall();
+};

--- a/modules/games_enet_webrtc/fake_address_map.cpp
+++ b/modules/games_enet_webrtc/fake_address_map.cpp
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*  fake_address_map.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "fake_address_map.h"
+#include "protocol.h"
+
+IPAddress FakeAddressMap::make_fake_ip(uint8_t p_n) {
+	return IPAddress(10, 66, 0, p_n);
+}
+
+bool FakeAddressMap::is_fake_ip(const IPAddress &p_ip) {
+	if (!p_ip.is_valid() || !p_ip.is_ipv4()) {
+		return false;
+	}
+	const uint8_t *b = p_ip.get_ipv4();
+	return b[0] == 10 && b[1] == 66 && b[2] == 0 && b[3] >= 1 && b[3] <= 254;
+}
+
+void FakeAddressMap::clear() {
+	by_signal.clear();
+	MutexLock lock(inbound_mutex);
+	inbound.clear();
+}
+
+void FakeAddressMap::add_peer(const FakePeerEntry &p_entry) {
+	by_signal[p_entry.signal_id] = p_entry;
+}
+
+void FakeAddressMap::remove_signal(int p_signal_id) {
+	by_signal.erase(p_signal_id);
+}
+
+void FakeAddressMap::set_link(int p_signal_id, WebRTCLink *p_link) {
+	if (by_signal.has(p_signal_id)) {
+		by_signal[p_signal_id].link = p_link;
+	}
+}
+
+void FakeAddressMap::set_relay(int p_signal_id, bool p_relay) {
+	if (by_signal.has(p_signal_id)) {
+		by_signal[p_signal_id].relay = p_relay;
+	}
+}
+
+bool FakeAddressMap::lookup_signal(int p_signal_id, FakePeerEntry &r_entry) const {
+	if (!by_signal.has(p_signal_id)) {
+		return false;
+	}
+	r_entry = by_signal[p_signal_id];
+	return true;
+}
+
+bool FakeAddressMap::lookup_addr(const IPAddress &p_ip, uint16_t p_port, FakePeerEntry &r_entry) const {
+	for (const KeyValue<int, FakePeerEntry> &E : by_signal) {
+		if (E.value.fake_ip == p_ip && E.value.fake_port == p_port) {
+			r_entry = E.value;
+			return true;
+		}
+	}
+	return false;
+}
+
+void FakeAddressMap::push_inbound(const Vector<uint8_t> &p_data, const IPAddress &p_src_ip, uint16_t p_src_port) {
+	if (p_data.is_empty() || p_data.size() > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES) {
+		return;
+	}
+	InboundDatagram d;
+	d.data = p_data;
+	d.src_ip = p_src_ip;
+	d.src_port = p_src_port;
+	MutexLock lock(inbound_mutex);
+	while (inbound.size() >= GamesEnetWebrtcProtocol::MAX_INBOUND_DATAGRAMS) {
+		inbound.pop_front();
+	}
+	inbound.push_back(d);
+}
+
+bool FakeAddressMap::pop_inbound(InboundDatagram &r_out) {
+	MutexLock lock(inbound_mutex);
+	if (inbound.is_empty()) {
+		return false;
+	}
+	r_out = inbound.front()->get();
+	inbound.pop_front();
+	return true;
+}
+
+int FakeAddressMap::inbound_size() {
+	MutexLock lock(inbound_mutex);
+	return inbound.size();
+}

--- a/modules/games_enet_webrtc/fake_address_map.h
+++ b/modules/games_enet_webrtc/fake_address_map.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  fake_address_map.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/ip_address.h"
+#include "core/os/mutex.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/list.h"
+#include "core/templates/vector.h"
+
+class WebRTCLink;
+
+struct FakePeerEntry {
+	int signal_id = 0;
+	IPAddress fake_ip;
+	uint16_t fake_port = 1;
+	String role;
+	String name;
+	WebRTCLink *link = nullptr;
+	bool relay = false;
+};
+
+struct InboundDatagram {
+	Vector<uint8_t> data;
+	IPAddress src_ip;
+	uint16_t src_port = 0;
+};
+
+class FakeAddressMap {
+	HashMap<int, FakePeerEntry> by_signal;
+	Mutex inbound_mutex;
+	List<InboundDatagram> inbound;
+
+public:
+	static IPAddress make_fake_ip(uint8_t p_n);
+	static bool is_fake_ip(const IPAddress &p_ip);
+
+	void clear();
+	void add_peer(const FakePeerEntry &p_entry);
+	void remove_signal(int p_signal_id);
+	void set_link(int p_signal_id, WebRTCLink *p_link);
+	void set_relay(int p_signal_id, bool p_relay);
+
+	bool lookup_signal(int p_signal_id, FakePeerEntry &r_entry) const;
+	bool lookup_addr(const IPAddress &p_ip, uint16_t p_port, FakePeerEntry &r_entry) const;
+
+	void push_inbound(const Vector<uint8_t> &p_data, const IPAddress &p_src_ip, uint16_t p_src_port);
+	bool pop_inbound(InboundDatagram &r_out);
+	int inbound_size();
+};

--- a/modules/games_enet_webrtc/protocol.cpp
+++ b/modules/games_enet_webrtc/protocol.cpp
@@ -1,0 +1,495 @@
+/**************************************************************************/
+/*  protocol.cpp                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "protocol.h"
+
+#include "core/crypto/crypto_core.h"
+#include "core/io/ip_address.h"
+#include "core/io/json.h"
+#include "core/string/ustring.h"
+
+namespace GamesEnetWebrtcProtocol {
+
+static bool _charset_id(char32_t c) {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-';
+}
+
+static bool _crockford(char32_t c) {
+	if (c >= 'a' && c <= 'z') {
+		c = c - 'a' + 'A';
+	}
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'H') || (c >= 'J' && c <= 'K') || (c >= 'M' && c <= 'N') || (c >= 'P' && c <= 'T') || (c >= 'V' && c <= 'Z');
+}
+
+bool has_crlf(const String &p_s) {
+	return p_s.contains("\r") || p_s.contains("\n");
+}
+
+String strip_controls(const String &p_s) {
+	String out;
+	for (int i = 0; i < p_s.length(); i++) {
+		const char32_t c = p_s[i];
+		if (c >= 32 && c != 127) {
+			out += c;
+		}
+	}
+	return out.strip_edges();
+}
+
+bool is_valid_game_id(const String &p_id) {
+	if (p_id.is_empty() || p_id.length() > MAX_GAME_ID || has_crlf(p_id)) {
+		return false;
+	}
+	for (int i = 0; i < p_id.length(); i++) {
+		if (!_charset_id(p_id[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static String _host_from_hostport(const String &p_hp) {
+	String hp = p_hp;
+	const int q = hp.find("?");
+	if (q >= 0) {
+		hp = hp.substr(0, q);
+	}
+	if (hp.begins_with("[")) {
+		const int br = hp.find("]");
+		if (br <= 1) {
+			return String();
+		}
+		return hp.substr(1, br - 1);
+	}
+	const int colon = hp.rfind(":");
+	if (colon >= 0) {
+		return hp.substr(0, colon);
+	}
+	return hp;
+}
+
+static bool _looks_like_ip(const String &p_host) {
+	if (p_host.contains(":")) {
+		return true;
+	}
+	const PackedStringArray parts = p_host.split(".");
+	if (parts.size() != 4) {
+		return false;
+	}
+	for (int i = 0; i < 4; i++) {
+		if (parts[i].is_empty() || !parts[i].is_valid_int()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool _is_denied_url_host(const String &p_host) {
+	if (p_host.is_empty()) {
+		return true;
+	}
+	if (!_looks_like_ip(p_host)) {
+		return false;
+	}
+	const IPAddress ip(p_host);
+	if (!ip.is_valid()) {
+		return true;
+	}
+	if (ip.is_ipv4()) {
+		const uint8_t *b = ip.get_ipv4();
+		if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0) {
+			return true;
+		}
+		if (b[0] == 127) {
+			return false;
+		}
+		if (b[0] == 169 && b[1] == 254) {
+			return true;
+		}
+		if (b[0] == 100 && b[1] == 100 && b[2] == 100 && b[3] == 200) {
+			return true;
+		}
+		if (b[0] >= 224) {
+			return true;
+		}
+		return false;
+	}
+	const uint8_t *v6 = ip.get_ipv6();
+	bool unspecified = true;
+	for (int i = 0; i < 16; i++) {
+		if (v6[i] != 0) {
+			unspecified = false;
+			break;
+		}
+	}
+	if (unspecified) {
+		return true;
+	}
+	bool loopback = true;
+	for (int i = 0; i < 15; i++) {
+		if (v6[i] != 0) {
+			loopback = false;
+			break;
+		}
+	}
+	if (loopback && v6[15] == 1) {
+		return false;
+	}
+	if (v6[0] == 0xfe && (v6[1] & 0xc0) == 0x80) {
+		return true;
+	}
+	if (v6[0] == 0xff) {
+		return true;
+	}
+	return false;
+}
+
+bool is_valid_signal_url(const String &p_url) {
+	if (has_crlf(p_url) || p_url.length() > 1024 || p_url.contains(" ") || p_url.contains("\t")) {
+		return false;
+	}
+	int start = 0;
+	if (p_url.begins_with("wss://")) {
+		start = 6;
+	} else if (p_url.begins_with("ws://")) {
+		start = 5;
+	} else {
+		return false;
+	}
+	String rest = p_url.substr(start);
+	const int slash = rest.find("/");
+	if (slash >= 0) {
+		rest = rest.substr(0, slash);
+	}
+	return !_is_denied_url_host(_host_from_hostport(rest));
+}
+
+bool is_valid_auth_token(const String &p_token) {
+	if (p_token.is_empty()) {
+		return true;
+	}
+	if (p_token.length() > MAX_AUTH_TOKEN || has_crlf(p_token)) {
+		return false;
+	}
+	for (int i = 0; i < p_token.length(); i++) {
+		if (p_token[i] < 32 || p_token[i] == 127) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool is_valid_room_code(const String &p_code) {
+	if (p_code.length() != 6) {
+		return false;
+	}
+	for (int i = 0; i < p_code.length(); i++) {
+		if (!_crockford(p_code[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool is_valid_room_name(const String &p_name) {
+	const String s = strip_controls(p_name);
+	return !s.is_empty() && s.length() <= MAX_ROOM_NAME && !has_crlf(s);
+}
+
+bool is_valid_password(const String &p_password) {
+	return p_password.length() <= MAX_PASSWORD && !has_crlf(p_password);
+}
+
+bool is_valid_signal_id(int p_id) {
+	return p_id >= MIN_SIGNAL_ID && p_id <= HARD_SIGNAL_CAP;
+}
+
+bool is_valid_fake_ip(const String &p_ip) {
+	const PackedStringArray parts = p_ip.split(".");
+	if (parts.size() != 4) {
+		return false;
+	}
+	if (parts[0] != "10" || parts[1] != "66" || parts[2] != "0") {
+		return false;
+	}
+	const int n = parts[3].to_int();
+	return n >= 1 && n <= HARD_SIGNAL_CAP && String::num_int64(n) == parts[3];
+}
+
+bool is_valid_fake_port(int p_port) {
+	return p_port == 1;
+}
+
+bool is_valid_sdp(const String &p_sdp) {
+	if (p_sdp.is_empty() || p_sdp.utf8().length() > MAX_SDP_BYTES) {
+		return false;
+	}
+	return p_sdp.begins_with("v=");
+}
+
+bool is_valid_candidate(const String &p_candidate) {
+	if (p_candidate.is_empty() || p_candidate.utf8().length() > MAX_CANDIDATE_BYTES) {
+		return false;
+	}
+	for (int i = 0; i < p_candidate.length(); i++) {
+		const char32_t c = p_candidate[i];
+		if (c < 32 || c > 126) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool is_valid_relay_payload(const Vector<uint8_t> &p_payload) {
+	return p_payload.size() > 0 && p_payload.size() <= MAX_RELAY_BYTES;
+}
+
+int clamp_max_clients(int p_max) {
+	if (p_max < 1) {
+		return 1;
+	}
+	if (p_max > ADVERTISED_ROOM_CAP) {
+		return ADVERTISED_ROOM_CAP;
+	}
+	return p_max;
+}
+
+String stringify_envelope(int p_type, int p_id, const Dictionary &p_data) {
+	Dictionary env;
+	env["v"] = PROTOCOL_VERSION;
+	env["type"] = p_type;
+	env["id"] = p_id;
+	env["data"] = p_data;
+	return JSON::stringify(env);
+}
+
+Envelope parse_envelope(const String &p_text) {
+	Envelope out;
+	if (p_text.utf8().length() > MAX_ENVELOPE_BYTES) {
+		return out;
+	}
+	Variant parsed = JSON::parse_string(p_text);
+	if (parsed.get_type() != Variant::DICTIONARY) {
+		return out;
+	}
+	Dictionary d = parsed;
+	out.v = int(d.get("v", 0));
+	out.type = int(d.get("type", -1));
+	out.id = int(d.get("id", 0));
+	if (!d.has("data") || d["data"].get_type() != Variant::DICTIONARY) {
+		return out;
+	}
+	out.data = d["data"];
+	out.valid = out.v == PROTOCOL_VERSION && out.type >= MSG_JOIN && out.type <= MSG_KICK;
+	if (out.valid && out.id != 0 && !is_valid_signal_id(out.id)) {
+		out.valid = false;
+	}
+	return out;
+}
+
+bool payload_within_limits(int p_type, const Dictionary &p_data) {
+	if (p_type == MSG_OFFER || p_type == MSG_ANSWER) {
+		return is_valid_sdp(String(p_data.get("sdp", "")));
+	}
+	if (p_type == MSG_CANDIDATE) {
+		return is_valid_candidate(String(p_data.get("candidate", "")));
+	}
+	if (p_type == MSG_RELAY_DATAGRAM) {
+		const String b64 = String(p_data.get("payload", ""));
+		if (b64.is_empty() || b64.length() > MAX_RELAY_BYTES * 2) {
+			return false;
+		}
+		const int to = int(p_data.get("to", 0));
+		if (to != 0 && !is_valid_signal_id(to)) {
+			return false;
+		}
+		const CharString cs = b64.ascii();
+		size_t decoded = 0;
+		Vector<uint8_t> buf;
+		buf.resize(cs.length());
+		if (CryptoCore::b64_decode(buf.ptrw(), buf.size(), &decoded, (const uint8_t *)cs.get_data(), cs.length()) != OK) {
+			return false;
+		}
+		buf.resize((int)decoded);
+		return is_valid_relay_payload(buf);
+	}
+	if (p_type == MSG_CREATE) {
+		return is_valid_room_name(String(p_data.get("name", ""))) && is_valid_password(String(p_data.get("password", "")));
+	}
+	if (p_type == MSG_JOIN) {
+		return is_valid_room_code(String(p_data.get("room_code", ""))) && is_valid_password(String(p_data.get("password", "")));
+	}
+	if (p_type == MSG_KICK) {
+		return is_valid_signal_id(int(p_data.get("signal_id", 0)));
+	}
+	return true;
+}
+
+bool is_valid_ice_url(const String &p_url) {
+	if (p_url.is_empty() || p_url.length() > 256 || has_crlf(p_url) || p_url.contains(" ") || p_url.contains("\t")) {
+		return false;
+	}
+	const String lower = p_url.to_lower();
+	String rest;
+	if (lower.begins_with("turns:")) {
+		rest = p_url.substr(6);
+	} else if (lower.begins_with("turn:")) {
+		rest = p_url.substr(5);
+	} else if (lower.begins_with("stun:")) {
+		rest = p_url.substr(5);
+	} else {
+		return false;
+	}
+	if (rest.is_empty() || rest.begins_with("//")) {
+		return false;
+	}
+	return !_is_denied_url_host(_host_from_hostport(rest));
+}
+
+bool is_valid_turn_username(const String &p_user) {
+	if (p_user.is_empty() || has_crlf(p_user) || p_user.length() > 256) {
+		return false;
+	}
+	const PackedStringArray parts = p_user.split(":");
+	if (parts.size() != 3) {
+		return false;
+	}
+	if (!parts[0].is_valid_int()) {
+		return false;
+	}
+	if (parts[1].is_empty() || parts[1].length() > 64) {
+		return false;
+	}
+	for (int i = 0; i < parts[1].length(); i++) {
+		if (!_charset_id(parts[1][i])) {
+			return false;
+		}
+	}
+	return is_valid_signal_id(parts[2].to_int()) && String::num_int64(parts[2].to_int()) == parts[2];
+}
+
+bool is_valid_role(const String &p_role) {
+	return p_role == "host" || p_role == "joiner";
+}
+
+bool is_star_pair(int p_a, int p_b) {
+	return (p_a == 1 || p_b == 1) && p_a != p_b && is_valid_signal_id(p_a) && is_valid_signal_id(p_b);
+}
+
+Array sanitize_ice_servers(const Array &p_servers) {
+	Array out;
+	for (int i = 0; i < p_servers.size() && out.size() < 8; i++) {
+		if (p_servers[i].get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+		Dictionary src = p_servers[i];
+		Array urls;
+		const Variant uv = src.get("urls", Variant());
+		if (uv.get_type() == Variant::ARRAY) {
+			urls = uv;
+		} else if (uv.get_type() == Variant::STRING && is_valid_ice_url(String(uv))) {
+			urls.push_back(String(uv));
+		}
+		Array kept;
+		for (int u = 0; u < urls.size(); u++) {
+			const String url = String(urls[u]);
+			if (is_valid_ice_url(url)) {
+				kept.push_back(url);
+			}
+		}
+		if (kept.is_empty()) {
+			continue;
+		}
+		Dictionary dst;
+		dst["urls"] = kept;
+		const String user = String(src.get("username", ""));
+		const String cred = String(src.get("credential", ""));
+		if (is_valid_turn_username(user) && !has_crlf(cred) && cred.length() <= 256) {
+			dst["username"] = user;
+			if (!cred.is_empty()) {
+				dst["credential"] = cred;
+			}
+		}
+		out.push_back(dst);
+	}
+	return out;
+}
+
+Array sanitize_room_list(const Array &p_rooms) {
+	Array out;
+	for (int i = 0; i < p_rooms.size() && out.size() < 100; i++) {
+		if (p_rooms[i].get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+		Dictionary src = p_rooms[i];
+		const String code = String(src.get("room_code", ""));
+		if (!is_valid_room_code(code)) {
+			continue;
+		}
+		Dictionary dst;
+		dst["room_code"] = code;
+		const String name = strip_controls(String(src.get("name", "")));
+		if (is_valid_room_name(name)) {
+			dst["name"] = name;
+		}
+		dst["max"] = clamp_max_clients(int(src.get("max", ADVERTISED_ROOM_CAP)));
+		int members = int(src.get("members", 0));
+		if (members < 0) {
+			members = 0;
+		}
+		if (members > HARD_SIGNAL_CAP) {
+			members = HARD_SIGNAL_CAP;
+		}
+		dst["members"] = members;
+		Variant tags_v = src.get("tags", Array());
+		Array src_tags;
+		if (tags_v.get_type() == Variant::PACKED_STRING_ARRAY) {
+			PackedStringArray psa = tags_v;
+			for (int t = 0; t < psa.size(); t++) {
+				src_tags.push_back(psa[t]);
+			}
+		} else if (tags_v.get_type() == Variant::ARRAY) {
+			src_tags = tags_v;
+		}
+		Array tags_out;
+		for (int t = 0; t < src_tags.size() && tags_out.size() < MAX_TAGS; t++) {
+			const String tag = strip_controls(String(src_tags[t]));
+			if (is_valid_game_id(tag) && tag.length() <= MAX_TAG_LEN) {
+				tags_out.push_back(tag);
+			}
+		}
+		if (!tags_out.is_empty()) {
+			dst["tags"] = tags_out;
+		}
+		out.push_back(dst);
+	}
+	return out;
+}
+
+} //namespace GamesEnetWebrtcProtocol

--- a/modules/games_enet_webrtc/protocol.h
+++ b/modules/games_enet_webrtc/protocol.h
@@ -1,0 +1,115 @@
+/**************************************************************************/
+/*  protocol.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+#include "core/variant/array.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+namespace GamesEnetWebrtcProtocol {
+
+enum MessageType {
+	MSG_JOIN = 0,
+	MSG_ID = 1,
+	MSG_PEER_CONNECT = 2,
+	MSG_PEER_DISCONNECT = 3,
+	MSG_OFFER = 4,
+	MSG_ANSWER = 5,
+	MSG_CANDIDATE = 6,
+	MSG_SEAL = 7,
+	MSG_HELLO = 8,
+	MSG_PEER_INFO = 9,
+	MSG_CREATE = 10,
+	MSG_LIST = 11,
+	MSG_LEAVE = 12,
+	MSG_PEER_READY = 13,
+	MSG_USE_RELAY = 14,
+	MSG_RELAY_DATAGRAM = 15,
+	MSG_ICE_CONFIG = 16,
+	MSG_ERROR = 17,
+	MSG_PING = 18,
+	MSG_KICK = 19,
+};
+
+enum {
+	PROTOCOL_VERSION = 1,
+	MAX_ENVELOPE_BYTES = 16 * 1024,
+	MAX_SDP_BYTES = 8 * 1024,
+	MAX_CANDIDATE_BYTES = 2 * 1024,
+	MAX_RELAY_BYTES = 1400,
+	MAX_GAME_ID = 64,
+	MAX_ROOM_NAME = 64,
+	MAX_PASSWORD = 128,
+	MAX_AUTH_TOKEN = 512,
+	MAX_TAG_LEN = 32,
+	MAX_TAGS = 8,
+	ADVERTISED_ROOM_CAP = 8,
+	HARD_SIGNAL_CAP = 254,
+	MIN_SIGNAL_ID = 1,
+	MAX_INBOUND_DATAGRAMS = 256,
+};
+
+struct Envelope {
+	int v = PROTOCOL_VERSION;
+	int type = 0;
+	int id = 0;
+	Dictionary data;
+	bool valid = false;
+};
+
+String stringify_envelope(int p_type, int p_id, const Dictionary &p_data);
+Envelope parse_envelope(const String &p_text);
+bool payload_within_limits(int p_type, const Dictionary &p_data);
+
+bool has_crlf(const String &p_s);
+bool is_valid_game_id(const String &p_id);
+bool is_valid_signal_url(const String &p_url);
+bool is_valid_auth_token(const String &p_token);
+bool is_valid_room_code(const String &p_code);
+bool is_valid_room_name(const String &p_name);
+bool is_valid_password(const String &p_password);
+bool is_valid_signal_id(int p_id);
+bool is_valid_fake_ip(const String &p_ip);
+bool is_valid_fake_port(int p_port);
+bool is_valid_sdp(const String &p_sdp);
+bool is_valid_candidate(const String &p_candidate);
+bool is_valid_relay_payload(const Vector<uint8_t> &p_payload);
+bool is_valid_ice_url(const String &p_url);
+bool is_valid_turn_username(const String &p_user);
+bool is_valid_role(const String &p_role);
+bool is_star_pair(int p_a, int p_b);
+Array sanitize_ice_servers(const Array &p_servers);
+Array sanitize_room_list(const Array &p_rooms);
+int clamp_max_clients(int p_max);
+String strip_controls(const String &p_s);
+
+} //namespace GamesEnetWebrtcProtocol

--- a/modules/games_enet_webrtc/register_types.cpp
+++ b/modules/games_enet_webrtc/register_types.cpp
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "signal_client.h"
+#include "webrtc_enet_session.h"
+#include "webrtc_link.h"
+
+#include "core/object/class_db.h"
+
+void initialize_games_enet_webrtc_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+	GDREGISTER_CLASS(SignalClient);
+	GDREGISTER_INTERNAL_CLASS(WebRTCLink);
+	GDREGISTER_CLASS(WebRTCEnetSession);
+}
+
+void uninitialize_games_enet_webrtc_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}

--- a/modules/games_enet_webrtc/register_types.h
+++ b/modules/games_enet_webrtc/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_games_enet_webrtc_module(ModuleInitializationLevel p_level);
+void uninitialize_games_enet_webrtc_module(ModuleInitializationLevel p_level);

--- a/modules/games_enet_webrtc/relay_client.cpp
+++ b/modules/games_enet_webrtc/relay_client.cpp
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  relay_client.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "relay_client.h"
+
+#include "protocol.h"
+#include "signal_client.h"
+
+#include "core/crypto/crypto_core.h"
+
+#include <cstring>
+
+Error RelayClient::send_datagram(int p_to_signal_id, const uint8_t *p_buffer, int p_len) {
+	ERR_FAIL_NULL_V(signal, ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(!GamesEnetWebrtcProtocol::is_valid_signal_id(p_to_signal_id), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_len <= 0 || p_len > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES, ERR_INVALID_PARAMETER);
+	Vector<uint8_t> raw;
+	raw.resize(p_len);
+	if (p_len > 0) {
+		memcpy(raw.ptrw(), p_buffer, p_len);
+	}
+	Dictionary data;
+	data["to"] = p_to_signal_id;
+	data["payload"] = CryptoCore::b64_encode_str(raw.ptr(), raw.size());
+	return signal->send_message(GamesEnetWebrtcProtocol::MSG_RELAY_DATAGRAM, data, p_to_signal_id);
+}
+
+bool RelayClient::decode_datagram(const Dictionary &p_data, int &r_from, Vector<uint8_t> &r_payload) {
+	r_from = int(p_data.get("from", 0));
+	if (r_from == 0) {
+		r_from = int(p_data.get("id", 0));
+	}
+	const String b64 = String(p_data.get("payload", ""));
+	if (b64.is_empty()) {
+		return false;
+	}
+	const CharString cs = b64.ascii();
+	size_t decoded_size = 0;
+	r_payload.resize(cs.length());
+	if (CryptoCore::b64_decode(r_payload.ptrw(), r_payload.size(), &decoded_size, (const uint8_t *)cs.get_data(), cs.length()) != OK) {
+		r_payload.clear();
+		return false;
+	}
+	r_payload.resize((int)decoded_size);
+	if (!GamesEnetWebrtcProtocol::is_valid_signal_id(r_from) || !GamesEnetWebrtcProtocol::is_valid_relay_payload(r_payload)) {
+		r_payload.clear();
+		return false;
+	}
+	return true;
+}

--- a/modules/games_enet_webrtc/relay_client.h
+++ b/modules/games_enet_webrtc/relay_client.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  relay_client.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/vector.h"
+#include "core/variant/dictionary.h"
+
+class SignalClient;
+
+class RelayClient {
+	SignalClient *signal = nullptr;
+
+public:
+	void set_signal_client(SignalClient *p_signal) { signal = p_signal; }
+	Error send_datagram(int p_to_signal_id, const uint8_t *p_buffer, int p_len);
+	static bool decode_datagram(const Dictionary &p_data, int &r_from, Vector<uint8_t> &r_payload);
+};

--- a/modules/games_enet_webrtc/signal_client.cpp
+++ b/modules/games_enet_webrtc/signal_client.cpp
@@ -1,0 +1,135 @@
+/**************************************************************************/
+/*  signal_client.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "signal_client.h"
+
+#include "protocol.h"
+
+#include "core/io/json.h"
+
+void SignalClient::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("configure", "url", "game_id", "auth_token"), &SignalClient::configure);
+	ClassDB::bind_method(D_METHOD("connect_to_signal"), &SignalClient::connect_to_signal);
+	ClassDB::bind_method(D_METHOD("close"), &SignalClient::close);
+	ClassDB::bind_method(D_METHOD("poll"), &SignalClient::poll);
+	ClassDB::bind_method(D_METHOD("send_message", "type", "data", "id"), &SignalClient::send_message, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_open"), &SignalClient::is_open);
+
+	ADD_SIGNAL(MethodInfo("connected"));
+	ADD_SIGNAL(MethodInfo("disconnected"));
+	ADD_SIGNAL(MethodInfo("message_received", PropertyInfo(Variant::INT, "type"), PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::DICTIONARY, "data")));
+}
+
+Error SignalClient::configure(const String &p_url, const String &p_game_id, const String &p_auth_token) {
+	if (!GamesEnetWebrtcProtocol::is_valid_signal_url(p_url) || !GamesEnetWebrtcProtocol::is_valid_game_id(p_game_id) || !GamesEnetWebrtcProtocol::is_valid_auth_token(p_auth_token)) {
+		url = String();
+		game_id = String();
+		auth_token = String();
+		return ERR_INVALID_PARAMETER;
+	}
+	url = p_url;
+	game_id = p_game_id;
+	auth_token = p_auth_token;
+	return OK;
+}
+
+Error SignalClient::connect_to_signal() {
+	ERR_FAIL_COND_V(!GamesEnetWebrtcProtocol::is_valid_signal_url(url) || !GamesEnetWebrtcProtocol::is_valid_game_id(game_id), ERR_UNCONFIGURED);
+	close();
+	ws = Ref<WebSocketPeer>(WebSocketPeer::create());
+	ERR_FAIL_COND_V(ws.is_null(), ERR_CANT_CREATE);
+	ws->set_inbound_buffer_size(GamesEnetWebrtcProtocol::MAX_ENVELOPE_BYTES + 1024);
+	ws->set_max_queued_packets(64);
+
+	PackedStringArray headers;
+	headers.push_back("X-Game-Id: " + game_id);
+	if (!auth_token.is_empty()) {
+		headers.push_back("Authorization: Bearer " + auth_token);
+	}
+	ws->set_handshake_headers(headers);
+
+	String connect_url = url;
+	if (connect_url.contains("?")) {
+		connect_url += "&game_id=" + game_id.uri_encode();
+	} else {
+		connect_url += "?game_id=" + game_id.uri_encode();
+	}
+	announced_open = false;
+	return ws->connect_to_url(connect_url);
+}
+
+void SignalClient::close() {
+	if (ws.is_valid()) {
+		ws->close();
+		ws.unref();
+	}
+	announced_open = false;
+}
+
+void SignalClient::poll() {
+	if (ws.is_null()) {
+		return;
+	}
+	ws->poll();
+	const WebSocketPeer::State st = ws->get_ready_state();
+	if (st == WebSocketPeer::STATE_OPEN) {
+		if (!announced_open) {
+			announced_open = true;
+			emit_signal("connected");
+		}
+		while (ws->get_available_packet_count() > 0) {
+			Vector<uint8_t> pkt;
+			ws->get_packet_buffer(pkt);
+			const String text = String::utf8((const char *)pkt.ptr(), pkt.size());
+			GamesEnetWebrtcProtocol::Envelope env = GamesEnetWebrtcProtocol::parse_envelope(text);
+			if (env.valid) {
+				emit_signal("message_received", env.type, env.id, env.data);
+			}
+		}
+	} else if (st == WebSocketPeer::STATE_CLOSED && announced_open) {
+		announced_open = false;
+		emit_signal("disconnected");
+	}
+}
+
+Error SignalClient::send_message(int p_type, const Dictionary &p_data, int p_id) {
+	ERR_FAIL_COND_V(ws.is_null() || ws->get_ready_state() != WebSocketPeer::STATE_OPEN, ERR_UNAVAILABLE);
+	if (p_id != 0 && !GamesEnetWebrtcProtocol::is_valid_signal_id(p_id)) {
+		return ERR_INVALID_PARAMETER;
+	}
+	if (!GamesEnetWebrtcProtocol::payload_within_limits(p_type, p_data)) {
+		return ERR_INVALID_PARAMETER;
+	}
+	const String text = GamesEnetWebrtcProtocol::stringify_envelope(p_type, p_id, p_data);
+	return ws->send_text(text);
+}
+
+bool SignalClient::is_open() const {
+	return ws.is_valid() && ws->get_ready_state() == WebSocketPeer::STATE_OPEN;
+}

--- a/modules/games_enet_webrtc/signal_client.h
+++ b/modules/games_enet_webrtc/signal_client.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  signal_client.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/variant/dictionary.h"
+#include "modules/websocket/websocket_peer.h"
+
+class SignalClient : public RefCounted {
+	GDCLASS(SignalClient, RefCounted);
+
+	String url;
+	String game_id;
+	String auth_token;
+	Ref<WebSocketPeer> ws;
+	bool announced_open = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Error configure(const String &p_url, const String &p_game_id, const String &p_auth_token);
+	Error connect_to_signal();
+	void close();
+	void poll();
+	Error send_message(int p_type, const Dictionary &p_data, int p_id = 0);
+	bool is_open() const;
+
+	String get_url() const { return url; }
+	String get_game_id() const { return game_id; }
+};

--- a/modules/games_enet_webrtc/tests/test_games_enet_webrtc.cpp
+++ b/modules/games_enet_webrtc/tests/test_games_enet_webrtc.cpp
@@ -1,0 +1,249 @@
+/**************************************************************************/
+/*  test_games_enet_webrtc.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_games_enet_webrtc.h"
+
+#include "../enet_webrtc_socket.h"
+#include "../enet_webrtc_socket_factory.h"
+#include "../relay_client.h"
+#include "../signal_client.h"
+#include "../webrtc_enet_session.h"
+#include "../webrtc_link.h"
+
+#include "core/crypto/crypto_core.h"
+
+namespace TestGamesEnetWebrtc {
+
+void test_enet_webrtc_socket_queue() {
+	FakeAddressMap map;
+	ENetWebRTCSocket sock(&map, nullptr);
+	CHECK(sock.bind(FakeAddressMap::make_fake_ip(1), 1) == OK);
+	IPAddress ip;
+	uint16_t port = 0;
+	int read = 0;
+	uint8_t buf[16];
+	CHECK(sock.recvfrom(buf, 16, read, ip, port) == ERR_BUSY);
+	CHECK(read == 0);
+
+	Vector<uint8_t> payload;
+	payload.resize(4);
+	payload.ptrw()[0] = 1;
+	payload.ptrw()[1] = 2;
+	payload.ptrw()[2] = 3;
+	payload.ptrw()[3] = 4;
+	map.push_inbound(payload, FakeAddressMap::make_fake_ip(2), 1);
+	CHECK(sock.recvfrom(buf, 16, read, ip, port) == OK);
+	CHECK(read == 4);
+	CHECK(buf[0] == 1);
+	CHECK(buf[3] == 4);
+	CHECK(port == 1);
+
+	int sent = 0;
+	CHECK(sock.sendto(buf, 4, sent, FakeAddressMap::make_fake_ip(2), 1) == ERR_UNCONFIGURED);
+
+	WebRTCEnetSession session;
+	ENetWebRTCSocket mapped(&map, &session);
+	CHECK(mapped.bind(FakeAddressMap::make_fake_ip(1), 1) == OK);
+	int mapped_sent = 0;
+	CHECK(mapped.sendto(buf, 4, mapped_sent, FakeAddressMap::make_fake_ip(9), 1) == ERR_BUSY);
+	CHECK(session.send_datagram(FakeAddressMap::make_fake_ip(9), 1, buf, 4) == ERR_BUSY);
+
+	FakeAddressMap q;
+	Vector<uint8_t> one;
+	one.resize(1);
+	one.ptrw()[0] = 1;
+	for (int i = 0; i < GamesEnetWebrtcProtocol::MAX_INBOUND_DATAGRAMS + 8; i++) {
+		one.ptrw()[0] = (uint8_t)(i & 0xff);
+		q.push_inbound(one, FakeAddressMap::make_fake_ip(2), 1);
+	}
+	CHECK(q.inbound_size() == GamesEnetWebrtcProtocol::MAX_INBOUND_DATAGRAMS);
+
+	Vector<uint8_t> huge;
+	huge.resize(GamesEnetWebrtcProtocol::MAX_RELAY_BYTES + 8);
+	const int before = q.inbound_size();
+	q.push_inbound(huge, FakeAddressMap::make_fake_ip(2), 1);
+	CHECK(q.inbound_size() == before);
+
+	int neg_sent = 0;
+	CHECK(mapped.sendto(nullptr, 4, neg_sent, FakeAddressMap::make_fake_ip(9), 1) == ERR_INVALID_PARAMETER);
+	CHECK(mapped.sendto(buf, 0, neg_sent, FakeAddressMap::make_fake_ip(9), 1) == ERR_INVALID_PARAMETER);
+	CHECK(mapped.sendto(buf, -1, neg_sent, FakeAddressMap::make_fake_ip(9), 1) == ERR_INVALID_PARAMETER);
+	int bad_read = 0;
+	IPAddress bad_ip;
+	uint16_t bad_port = 0;
+	CHECK(mapped.recvfrom(nullptr, 16, bad_read, bad_ip, bad_port) == ERR_INVALID_PARAMETER);
+
+	Ref<SignalClient> sc;
+	sc.instantiate();
+	CHECK(sc->configure("http://evil.example/v1", "ok-game", "") == ERR_INVALID_PARAMETER);
+	CHECK(sc->configure("ws://127.0.0.1:8080/v1/signal", "bad id", "") == ERR_INVALID_PARAMETER);
+	CHECK(sc->configure("ws://127.0.0.1:8080/v1/signal", "ok-game", "tok\nCRLF") == ERR_INVALID_PARAMETER);
+	CHECK(sc->configure("ws://127.0.0.1:8080/v1/signal", "ok-game", "") == OK);
+	CHECK(sc->get_url() == "ws://127.0.0.1:8080/v1/signal");
+	CHECK(sc->get_game_id() == "ok-game");
+	CHECK_FALSE(sc->is_open());
+	Ref<SignalClient> sc_unconf;
+	sc_unconf.instantiate();
+	CHECK(sc_unconf->connect_to_signal() == ERR_UNCONFIGURED);
+
+	Dictionary relay_ok;
+	relay_ok["from"] = 2;
+	uint8_t raw[3] = { 9, 8, 7 };
+	relay_ok["payload"] = CryptoCore::b64_encode_str(raw, 3);
+	int from = 0;
+	Vector<uint8_t> decoded;
+	CHECK(RelayClient::decode_datagram(relay_ok, from, decoded));
+	CHECK(from == 2);
+	CHECK(decoded.size() == 3);
+	CHECK(decoded[0] == 9);
+	Dictionary relay_empty;
+	relay_empty["from"] = 2;
+	relay_empty["payload"] = "";
+	CHECK_FALSE(RelayClient::decode_datagram(relay_empty, from, decoded));
+	Dictionary relay_from0;
+	relay_from0["from"] = 0;
+	relay_from0["payload"] = relay_ok["payload"];
+	CHECK_FALSE(RelayClient::decode_datagram(relay_from0, from, decoded));
+	Dictionary relay_from_id;
+	relay_from_id["id"] = 3;
+	relay_from_id["payload"] = relay_ok["payload"];
+	CHECK(RelayClient::decode_datagram(relay_from_id, from, decoded));
+	CHECK(from == 3);
+
+	WebRTCEnetSession sess;
+	CHECK(sess.configure("http://evil.example/v1", "ok-game", "") == ERR_INVALID_PARAMETER);
+	CHECK(sess.configure("ws://127.0.0.1:8080/v1/signal", "ok-game", "") == OK);
+	CHECK_FALSE(sess.is_in_room());
+	CHECK(sess.get_peer().is_null());
+	sess.set_ice_timeout_msec(99999);
+	CHECK(sess.get_ice_timeout_msec() == 60000);
+	sess.set_ice_timeout_msec(-5);
+	CHECK(sess.get_ice_timeout_msec() == 0);
+	sess.set_ice_timeout_msec(0);
+	CHECK(sess.get_ice_timeout_msec() == 0);
+	CHECK(sess.get_room_code().is_empty());
+	sess.set_force_relay(true);
+	CHECK(sess.get_force_relay());
+	CHECK(sess.leave() == ERR_UNCONFIGURED);
+	CHECK(sess.kick(2) == ERR_UNCONFIGURED);
+	CHECK(sess.kick(0) == ERR_UNCONFIGURED);
+	CHECK(sess.seal() == ERR_UNCONFIGURED);
+	CHECK(sess.get_local_fake_port() == 1);
+
+	IPAddress bound;
+	uint16_t bound_port = 0;
+	ENetWebRTCSocket unbound(&map, &session);
+	IPAddress unbound_ip;
+	uint16_t unbound_port = 0;
+	CHECK(unbound.get_socket_address(&unbound_ip, &unbound_port) == ERR_UNCONFIGURED);
+	int oversize_sent = 0;
+	Vector<uint8_t> oversize;
+	oversize.resize(GamesEnetWebrtcProtocol::MAX_RELAY_BYTES + 1);
+	CHECK(mapped.sendto(oversize.ptr(), oversize.size(), oversize_sent, FakeAddressMap::make_fake_ip(2), 1) == ERR_INVALID_PARAMETER);
+	int zero_read = 0;
+	CHECK(mapped.recvfrom(buf, 0, zero_read, ip, port) == ERR_INVALID_PARAMETER);
+	CHECK(mapped.get_socket_address(&bound, &bound_port) == OK);
+	CHECK(bound_port == 1);
+	CHECK(mapped.set_option(0, 1) == 0);
+	CHECK_FALSE(mapped.can_upgrade());
+	Vector<uint8_t> eight;
+	eight.resize(8);
+	for (int i = 0; i < 8; i++) {
+		eight.ptrw()[i] = (uint8_t)(i + 1);
+	}
+	map.push_inbound(eight, FakeAddressMap::make_fake_ip(2), 1);
+	uint8_t trunc_buf[4];
+	int trunc_read = 0;
+	IPAddress trunc_ip;
+	uint16_t trunc_port = 0;
+	CHECK(mapped.recvfrom(trunc_buf, 4, trunc_read, trunc_ip, trunc_port) == ERR_OUT_OF_MEMORY);
+	CHECK(trunc_read == 4);
+	CHECK(trunc_buf[0] == 1);
+	mapped.close();
+	int after_close = 0;
+	CHECK(mapped.recvfrom(buf, 16, after_close, ip, port) == ERR_BUSY);
+
+	Ref<WebRTCLink> link;
+	link.instantiate();
+	link->set_mode(WebRTCLink::MODE_RELAY);
+	CHECK(link->get_mode() == WebRTCLink::MODE_RELAY);
+	CHECK(link->is_open());
+	link->poll();
+	int dummy_sent = 0;
+	(void)dummy_sent;
+	CHECK(link->send(nullptr, 4) == ERR_INVALID_PARAMETER);
+	uint8_t tiny[2] = { 1, 2 };
+	CHECK(link->send(tiny, 2) == ERR_UNAVAILABLE);
+	Vector<uint8_t> too_big;
+	too_big.resize(GamesEnetWebrtcProtocol::MAX_RELAY_BYTES + 1);
+	CHECK(link->send(too_big.ptr(), too_big.size()) == ERR_INVALID_PARAMETER);
+	link->close();
+
+	RelayClient rc;
+	CHECK(rc.send_datagram(2, tiny, 2) == ERR_UNCONFIGURED);
+	Ref<SignalClient> sc2;
+	sc2.instantiate();
+	sc2->configure("ws://127.0.0.1:8080/v1/signal", "ok-game", "");
+	rc.set_signal_client(sc2.ptr());
+	CHECK(rc.send_datagram(0, tiny, 2) == ERR_INVALID_PARAMETER);
+	CHECK(rc.send_datagram(255, tiny, 2) == ERR_INVALID_PARAMETER);
+	CHECK(rc.send_datagram(2, tiny, 0) == ERR_INVALID_PARAMETER);
+	Dictionary empty_msg;
+	CHECK(sc2->send_message(GamesEnetWebrtcProtocol::MSG_PING, empty_msg) == ERR_UNAVAILABLE);
+
+	SIGNAL_WATCH(&sess, "failed");
+	sess.create_room("");
+	Array fail_args;
+	Array fail_one;
+	fail_one.push_back("invalid room fields");
+	fail_args.push_back(fail_one);
+	SIGNAL_CHECK("failed", fail_args);
+	sess.join_room("!!!!!!");
+	Array join_fail;
+	Array join_one;
+	join_one.push_back("invalid join fields");
+	join_fail.push_back(join_one);
+	SIGNAL_CHECK("failed", join_fail);
+	sess.create_room("pending-one");
+	sess.create_room("pending-two");
+	CHECK_FALSE(sess.is_in_room());
+	SIGNAL_UNWATCH(&sess, "failed");
+
+	{
+		ENetWebRTCSocketFactory::Guard guard(&map, &sess);
+		ENetSocketCreateFn fn = enet_get_socket_create_fn();
+		CHECK(fn != nullptr);
+		ENetGodotSocket *created = fn();
+		CHECK(created != nullptr);
+		memdelete(created);
+	}
+	CHECK(enet_get_socket_create_fn() == nullptr);
+}
+
+} //namespace TestGamesEnetWebrtc

--- a/modules/games_enet_webrtc/tests/test_games_enet_webrtc.h
+++ b/modules/games_enet_webrtc/tests/test_games_enet_webrtc.h
@@ -1,0 +1,385 @@
+/**************************************************************************/
+/*  test_games_enet_webrtc.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../fake_address_map.h"
+#include "../protocol.h"
+
+#include "tests/test_macros.h"
+
+namespace TestGamesEnetWebrtc {
+
+TEST_CASE("[Modules][GamesEnetWebrtc] protocol envelope roundtrip") {
+	Dictionary data;
+	data["room_code"] = "ABC123";
+	data["signal_id"] = 1;
+	const String json = GamesEnetWebrtcProtocol::stringify_envelope(GamesEnetWebrtcProtocol::MSG_HELLO, 0, data);
+	GamesEnetWebrtcProtocol::Envelope env = GamesEnetWebrtcProtocol::parse_envelope(json);
+	CHECK(env.valid);
+	CHECK(env.v == GamesEnetWebrtcProtocol::PROTOCOL_VERSION);
+	CHECK(env.type == GamesEnetWebrtcProtocol::MSG_HELLO);
+	CHECK(String(env.data["room_code"]) == "ABC123");
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] protocol rejects invalid json") {
+	GamesEnetWebrtcProtocol::Envelope env = GamesEnetWebrtcProtocol::parse_envelope("not-json");
+	CHECK_FALSE(env.valid);
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] SDP size limit") {
+	Dictionary data;
+	const String huge = String("a").repeat(GamesEnetWebrtcProtocol::MAX_SDP_BYTES + 8);
+	data["sdp"] = huge;
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_OFFER, data));
+	data["sdp"] = "v=0";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_OFFER, data));
+	data["sdp"] = "o=not-sdp";
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_sdp("o=not-sdp"));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] envelope oversize and type bounds") {
+	const String huge = String("x").repeat(GamesEnetWebrtcProtocol::MAX_ENVELOPE_BYTES + 8);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope(huge).valid);
+	Dictionary data;
+	data["room_code"] = "ABC123";
+	String bad = GamesEnetWebrtcProtocol::stringify_envelope(20, 0, data);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope(bad).valid);
+	bad = GamesEnetWebrtcProtocol::stringify_envelope(-1, 0, data);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":-1,\"id\":0,\"data\":{}}").valid);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":18,\"id\":255,\"data\":{}}").valid);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":18,\"id\":-1,\"data\":{}}").valid);
+	CHECK(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":18,\"id\":0,\"data\":{}}").valid);
+	Dictionary ping;
+	ping["t"] = "ping";
+	const String ping_json = GamesEnetWebrtcProtocol::stringify_envelope(GamesEnetWebrtcProtocol::MSG_PING, 2, ping);
+	GamesEnetWebrtcProtocol::Envelope ping_env = GamesEnetWebrtcProtocol::parse_envelope(ping_json);
+	CHECK(ping_env.valid);
+	CHECK(ping_env.id == 2);
+	CHECK(ping_env.type == GamesEnetWebrtcProtocol::MSG_PING);
+	Dictionary empty;
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_LIST, empty));
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_LEAVE, empty));
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_PING, empty));
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_SEAL, empty));
+	Dictionary relay_bad_to;
+	relay_bad_to["to"] = 255;
+	relay_bad_to["payload"] = "AQID";
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_RELAY_DATAGRAM, relay_bad_to));
+	Dictionary relay_ok;
+	relay_ok["to"] = 2;
+	relay_ok["payload"] = "AQID";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_RELAY_DATAGRAM, relay_ok));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] game_id and url sanitization") {
+	CHECK(GamesEnetWebrtcProtocol::is_valid_game_id("webrtc-enet-module-test"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_game_id("bad\r\nid"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_game_id("has space"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://127.0.0.1:8080/v1/signal"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_signal_url("wss://signal.example/v1"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_signal_url("http://evil"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://x y"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://evil\r\nHost: h"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_auth_token("tok\nCRLF"));
+	Dictionary join_bad;
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_JOIN, join_bad));
+	join_bad["room_code"] = "ABC234";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_JOIN, join_bad));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] fake ip sanitization") {
+	CHECK(GamesEnetWebrtcProtocol::is_valid_fake_ip("10.66.0.1"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_fake_ip("10.66.0.254"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_fake_ip("8.8.8.8"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_fake_ip("10.66.0.0"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_fake_ip("10.66.1.1"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_fake_ip("10.66.0.01"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_fake_port(1));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_fake_port(0));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] candidate and relay limits") {
+	CHECK(GamesEnetWebrtcProtocol::is_valid_candidate("candidate:1 1 UDP 1 1.2.3.4 9 typ host"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_candidate(String("a").repeat(GamesEnetWebrtcProtocol::MAX_CANDIDATE_BYTES + 2)));
+	Vector<uint8_t> ok;
+	ok.resize(16);
+	CHECK(GamesEnetWebrtcProtocol::is_valid_relay_payload(ok));
+	Vector<uint8_t> huge;
+	huge.resize(GamesEnetWebrtcProtocol::MAX_RELAY_BYTES + 1);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_relay_payload(huge));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] ICE url sanitization") {
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:127.0.0.1:3478"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("STUN:127.0.0.1:3478"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("turn:example.com:3478?transport=udp"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("turns:example.com:5349"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("http://evil"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:x\r\nHost: h"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun://example.com:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:has space"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:127.0.0.1:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:169.254.169.254:80"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:0.0.0.0:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://169.254.169.254/v1"));
+	CHECK(GamesEnetWebrtcProtocol::clamp_max_clients(999) == 8);
+	CHECK(GamesEnetWebrtcProtocol::clamp_max_clients(0) == 1);
+	Array servers;
+	Dictionary bad;
+	bad["urls"] = "http://no";
+	servers.push_back(bad);
+	Dictionary good;
+	Array urls;
+	urls.push_back("stun:127.0.0.1:3478");
+	good["urls"] = urls;
+	servers.push_back(good);
+	Array kept = GamesEnetWebrtcProtocol::sanitize_ice_servers(servers);
+	CHECK(kept.size() == 1);
+	Array many;
+	for (int i = 0; i < 12; i++) {
+		Dictionary d;
+		Array u;
+		u.push_back("stun:127.0.0.1:3478");
+		d["urls"] = u;
+		many.push_back(d);
+	}
+	CHECK(GamesEnetWebrtcProtocol::sanitize_ice_servers(many).size() == 8);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url(""));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url(String("stun:") + String("x").repeat(300)));
+	Dictionary crlf_user;
+	Array stun_urls;
+	stun_urls.push_back("stun:127.0.0.1:3478");
+	crlf_user["urls"] = stun_urls;
+	crlf_user["username"] = "bad\nuser";
+	crlf_user["credential"] = "ok";
+	Array mixed;
+	mixed.push_back(crlf_user);
+	Array sanitized = GamesEnetWebrtcProtocol::sanitize_ice_servers(mixed);
+	CHECK(sanitized.size() == 1);
+	Dictionary out0 = sanitized[0];
+	CHECK_FALSE(out0.has("username"));
+	CHECK_FALSE(out0.has("credential"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_turn_username("1700000000:ABC234:2"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_turn_username("not-a-user"));
+	CHECK(GamesEnetWebrtcProtocol::is_star_pair(1, 2));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_star_pair(2, 3));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_star_pair(1, 1));
+	Dictionary create_bad;
+	create_bad["name"] = "";
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_CREATE, create_bad));
+	Dictionary create_ok;
+	create_ok["name"] = "ok";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_CREATE, create_ok));
+	Dictionary kick_bad;
+	kick_bad["signal_id"] = 0;
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_KICK, kick_bad));
+	kick_bad["signal_id"] = 255;
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_KICK, kick_bad));
+	kick_bad["signal_id"] = 2;
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_KICK, kick_bad));
+	Array listed;
+	Dictionary row;
+	row["room_code"] = "ABC234";
+	row["name"] = "  ok  ";
+	row["max"] = 99;
+	row["members"] = 2;
+	row["password"] = "secret";
+	Array row_tags;
+	row_tags.push_back("modtest");
+	row_tags.push_back("bad tag");
+	row["tags"] = row_tags;
+	listed.push_back(row);
+	Dictionary junk;
+	junk["room_code"] = "!!!!!!";
+	listed.push_back(junk);
+	Array listed_clean = GamesEnetWebrtcProtocol::sanitize_room_list(listed);
+	CHECK(listed_clean.size() == 1);
+	Dictionary listed_row = listed_clean[0];
+	CHECK(String(listed_row["room_code"]) == "ABC234");
+	CHECK_FALSE(listed_row.has("password"));
+	CHECK(listed_row.has("tags"));
+	Array kept_tags = listed_row["tags"];
+	CHECK(kept_tags.size() == 1);
+	CHECK(String(kept_tags[0]) == "modtest");
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] valid HELLO-shaped dict") {
+	Dictionary hello;
+	hello["signal_id"] = 1;
+	hello["fake_ip"] = "10.66.0.1";
+	hello["fake_port"] = 1;
+	hello["room_code"] = "ABC234";
+	CHECK(GamesEnetWebrtcProtocol::is_valid_signal_id(int(hello["signal_id"])));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_fake_ip(String(hello["fake_ip"])));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_room_code(String(hello["room_code"])));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] fake address map") {
+	FakeAddressMap map;
+	FakePeerEntry host;
+	host.signal_id = 1;
+	host.fake_ip = FakeAddressMap::make_fake_ip(1);
+	host.fake_port = 1;
+	host.role = "host";
+	map.add_peer(host);
+
+	FakePeerEntry joiner;
+	joiner.signal_id = 2;
+	joiner.fake_ip = FakeAddressMap::make_fake_ip(2);
+	joiner.fake_port = 1;
+	map.add_peer(joiner);
+
+	CHECK(FakeAddressMap::is_fake_ip(host.fake_ip));
+	CHECK_FALSE(FakeAddressMap::is_fake_ip(IPAddress(10, 66, 1, 1)));
+	CHECK_FALSE(FakeAddressMap::is_fake_ip(IPAddress(10, 66, 0, 0)));
+	CHECK_FALSE(FakeAddressMap::is_fake_ip(IPAddress(10, 66, 0, 255)));
+	FakePeerEntry found;
+	CHECK(map.lookup_signal(1, found));
+	CHECK(found.signal_id == 1);
+	CHECK(map.lookup_addr(joiner.fake_ip, 1, found));
+	CHECK(found.signal_id == 2);
+	CHECK_FALSE(map.lookup_addr(joiner.fake_ip, 9, found));
+	map.remove_signal(2);
+	CHECK_FALSE(map.lookup_signal(2, found));
+	Vector<uint8_t> empty_in;
+	const int inbound_before = map.inbound_size();
+	map.push_inbound(empty_in, host.fake_ip, 1);
+	CHECK(map.inbound_size() == inbound_before);
+	map.set_relay(1, true);
+	CHECK(map.lookup_signal(1, found));
+	CHECK(found.relay);
+	map.set_link(1, nullptr);
+	CHECK(map.lookup_signal(1, found));
+	CHECK(found.link == nullptr);
+	Vector<uint8_t> inbound;
+	inbound.resize(2);
+	inbound.ptrw()[0] = 9;
+	inbound.ptrw()[1] = 8;
+	map.push_inbound(inbound, joiner.fake_ip, 1);
+	InboundDatagram popped;
+	CHECK(map.pop_inbound(popped));
+	CHECK(popped.data.size() == 2);
+	CHECK(popped.data[0] == 9);
+	map.clear();
+	CHECK_FALSE(map.lookup_signal(1, found));
+	CHECK_FALSE(map.pop_inbound(popped));
+}
+
+TEST_CASE("[Modules][GamesEnetWebrtc] remaining protocol helpers") {
+	CHECK(GamesEnetWebrtcProtocol::is_valid_room_code("ABC234"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_room_code("ILOUxx"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_room_code("ABC23"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_room_code("ABC2345"));
+	String ctrl = "  a";
+	ctrl += String::chr(1);
+	ctrl += "b  ";
+	CHECK(GamesEnetWebrtcProtocol::strip_controls(ctrl) == "ab");
+	CHECK(GamesEnetWebrtcProtocol::has_crlf("x\ny"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::has_crlf("ok"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_role("host"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_role("joiner"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_role("evil"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_password(""));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_password(String("p").repeat(GamesEnetWebrtcProtocol::MAX_PASSWORD + 1)));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_auth_token(""));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_game_id(String("a").repeat(GamesEnetWebrtcProtocol::MAX_GAME_ID + 1)));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:[::1]:3478"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://[::1]/v1"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:::3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:[fe80::1]:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:[ff02::1]:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:224.0.0.1:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:100.100.100.200:3478"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_signal_url("ws://224.0.0.1/v1"));
+	Dictionary cred_ok;
+	Array cred_urls;
+	cred_urls.push_back("turn:example.com:3478?transport=udp");
+	cred_ok["urls"] = cred_urls;
+	cred_ok["username"] = "1700000000:ABC234:2";
+	cred_ok["credential"] = "secret";
+	Array cred_in;
+	cred_in.push_back(cred_ok);
+	Array cred_out = GamesEnetWebrtcProtocol::sanitize_ice_servers(cred_in);
+	CHECK(cred_out.size() == 1);
+	Dictionary cred_row = cred_out[0];
+	CHECK(String(cred_row["username"]) == "1700000000:ABC234:2");
+	CHECK(String(cred_row["credential"]) == "secret");
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":18,\"id\":0,\"data\":[]}").valid);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::parse_envelope("{\"v\":1,\"type\":18,\"id\":0}").valid);
+	Dictionary answer;
+	answer["sdp"] = "v=0";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_ANSWER, answer));
+	Dictionary cand;
+	cand["candidate"] = "candidate:1 1 UDP 1 1.2.3.4 9 typ host";
+	CHECK(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_CANDIDATE, cand));
+	Dictionary relay_b64;
+	relay_b64["to"] = 2;
+	relay_b64["payload"] = "!!!not-b64!!!";
+	CHECK_FALSE(GamesEnetWebrtcProtocol::payload_within_limits(GamesEnetWebrtcProtocol::MSG_RELAY_DATAGRAM, relay_b64));
+	Array many_tags;
+	Dictionary tag_row;
+	tag_row["room_code"] = "ABC234";
+	tag_row["members"] = 999;
+	Array tags;
+	for (int i = 0; i < 12; i++) {
+		tags.push_back("t" + String::num_int64(i));
+	}
+	tag_row["tags"] = tags;
+	many_tags.push_back(tag_row);
+	Array cleaned_tags = GamesEnetWebrtcProtocol::sanitize_room_list(many_tags);
+	CHECK(cleaned_tags.size() == 1);
+	Dictionary cleaned_row = cleaned_tags[0];
+	CHECK(int(cleaned_row["members"]) == GamesEnetWebrtcProtocol::HARD_SIGNAL_CAP);
+	Array kept_tags = cleaned_row["tags"];
+	CHECK(kept_tags.size() == GamesEnetWebrtcProtocol::MAX_TAGS);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_turn_username("nocolon"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_turn_username("x:ABC234:2"));
+	CHECK(GamesEnetWebrtcProtocol::is_star_pair(1, 254));
+	CHECK(GamesEnetWebrtcProtocol::is_star_pair(254, 1));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_star_pair(254, 253));
+	CHECK(GamesEnetWebrtcProtocol::clamp_max_clients(1) == 1);
+	CHECK(GamesEnetWebrtcProtocol::clamp_max_clients(8) == 8);
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_auth_token(String("t").repeat(GamesEnetWebrtcProtocol::MAX_AUTH_TOKEN + 1)));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_auth_token("tok\x01"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_password("pw\r\n"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_sdp(""));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_candidate("cand\nidate"));
+	CHECK_FALSE(GamesEnetWebrtcProtocol::is_valid_ice_url("stun:[::]:3478"));
+	CHECK(GamesEnetWebrtcProtocol::is_valid_signal_url("wss://signal.example/v1"));
+	CHECK_FALSE(FakeAddressMap::is_fake_ip(FakeAddressMap::make_fake_ip(0)));
+}
+
+void test_enet_webrtc_socket_queue();
+
+TEST_CASE("[Modules][GamesEnetWebrtc] socket recvfrom empty and queued") {
+	test_enet_webrtc_socket_queue();
+}
+
+} //namespace TestGamesEnetWebrtc

--- a/modules/games_enet_webrtc/webrtc_enet_session.cpp
+++ b/modules/games_enet_webrtc/webrtc_enet_session.cpp
@@ -1,0 +1,637 @@
+/**************************************************************************/
+/*  webrtc_enet_session.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "webrtc_enet_session.h"
+
+#include "enet_webrtc_socket_factory.h"
+#include "protocol.h"
+
+#include "core/os/os.h"
+
+void WebRTCEnetSession::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("configure", "signal_url", "game_id", "auth_token"), &WebRTCEnetSession::configure);
+	ClassDB::bind_method(D_METHOD("create_room", "name", "max_clients", "password", "hidden", "tags"), &WebRTCEnetSession::create_room, DEFVAL(8), DEFVAL(String()), DEFVAL(false), DEFVAL(PackedStringArray()));
+	ClassDB::bind_method(D_METHOD("join_room", "room_code", "password", "display_name"), &WebRTCEnetSession::join_room, DEFVAL(String()), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("list_rooms"), &WebRTCEnetSession::list_rooms);
+	ClassDB::bind_method(D_METHOD("leave"), &WebRTCEnetSession::leave);
+	ClassDB::bind_method(D_METHOD("seal"), &WebRTCEnetSession::seal);
+	ClassDB::bind_method(D_METHOD("kick", "signal_id"), &WebRTCEnetSession::kick);
+	ClassDB::bind_method(D_METHOD("get_peer"), &WebRTCEnetSession::get_peer);
+	ClassDB::bind_method(D_METHOD("close"), &WebRTCEnetSession::close);
+	ClassDB::bind_method(D_METHOD("is_in_room"), &WebRTCEnetSession::is_in_room);
+	ClassDB::bind_method(D_METHOD("set_force_relay", "enable"), &WebRTCEnetSession::set_force_relay);
+	ClassDB::bind_method(D_METHOD("get_force_relay"), &WebRTCEnetSession::get_force_relay);
+	ClassDB::bind_method(D_METHOD("set_ice_timeout_msec", "msec"), &WebRTCEnetSession::set_ice_timeout_msec);
+	ClassDB::bind_method(D_METHOD("get_ice_timeout_msec"), &WebRTCEnetSession::get_ice_timeout_msec);
+	ClassDB::bind_method(D_METHOD("get_room_code"), &WebRTCEnetSession::get_room_code);
+	ClassDB::bind_method(D_METHOD("get_local_fake_ip"), &WebRTCEnetSession::get_local_fake_ip);
+	ClassDB::bind_method(D_METHOD("get_local_fake_port"), &WebRTCEnetSession::get_local_fake_port);
+	ClassDB::bind_method(D_METHOD("get_local_signal_id"), &WebRTCEnetSession::get_local_signal_id);
+
+	ADD_SIGNAL(MethodInfo("session_ready", PropertyInfo(Variant::STRING, "local_fake_ip"), PropertyInfo(Variant::INT, "local_fake_port"), PropertyInfo(Variant::STRING, "room_code")));
+	ADD_SIGNAL(MethodInfo("peer_link_up", PropertyInfo(Variant::STRING, "fake_ip"), PropertyInfo(Variant::INT, "fake_port"), PropertyInfo(Variant::INT, "signal_id")));
+	ADD_SIGNAL(MethodInfo("peer_link_down", PropertyInfo(Variant::STRING, "fake_ip"), PropertyInfo(Variant::INT, "fake_port"), PropertyInfo(Variant::INT, "signal_id")));
+	ADD_SIGNAL(MethodInfo("using_turn", PropertyInfo(Variant::INT, "signal_id")));
+	ADD_SIGNAL(MethodInfo("using_relay", PropertyInfo(Variant::INT, "signal_id")));
+	ADD_SIGNAL(MethodInfo("failed", PropertyInfo(Variant::STRING, "reason")));
+	ADD_SIGNAL(MethodInfo("rooms_listed", PropertyInfo(Variant::ARRAY, "rooms")));
+}
+
+WebRTCEnetSession::WebRTCEnetSession() {
+	signal_client.instantiate();
+	signal_client->connect("connected", callable_mp(this, &WebRTCEnetSession::_on_signal_connected));
+	signal_client->connect("disconnected", callable_mp(this, &WebRTCEnetSession::_on_signal_disconnected));
+	signal_client->connect("message_received", callable_mp(this, &WebRTCEnetSession::_on_signal_message));
+	relay.set_signal_client(signal_client.ptr());
+	set_process(false);
+}
+
+WebRTCEnetSession::~WebRTCEnetSession() {
+	close();
+}
+
+void WebRTCEnetSession::_notification(int p_what) {
+	if (p_what == NOTIFICATION_PROCESS) {
+		_poll();
+	}
+}
+
+void WebRTCEnetSession::_ensure_process() {
+	set_process(true);
+}
+
+Error WebRTCEnetSession::configure(const String &p_signal_url, const String &p_game_id, const String &p_auth_token) {
+	const Error err = signal_client->configure(p_signal_url, p_game_id, p_auth_token);
+	if (err != OK) {
+		signal_url = String();
+		game_id = String();
+		auth_token = String();
+		return err;
+	}
+	signal_url = p_signal_url;
+	game_id = p_game_id;
+	auth_token = p_auth_token;
+	return OK;
+}
+
+void WebRTCEnetSession::set_force_relay(bool p_enable) {
+	force_relay = p_enable;
+}
+
+void WebRTCEnetSession::set_ice_timeout_msec(int p_msec) {
+	ice_timeout_msec = CLAMP(p_msec, 0, 60000);
+}
+
+void WebRTCEnetSession::_fail(const String &p_reason) {
+	pending = OP_NONE;
+	emit_signal("failed", p_reason);
+}
+
+void WebRTCEnetSession::_poll() {
+	if (signal_client.is_valid()) {
+		signal_client->poll();
+		if (signal_client->is_open()) {
+			const uint64_t now = OS::get_singleton()->get_ticks_msec();
+			if (now - last_ping_msec >= 15000) {
+				last_ping_msec = now;
+				Dictionary ping;
+				ping["t"] = "ping";
+				signal_client->send_message(GamesEnetWebrtcProtocol::MSG_PING, ping);
+			}
+		}
+	}
+	for (KeyValue<int, Ref<WebRTCLink>> &E : links) {
+		if (E.value.is_valid()) {
+			E.value->poll();
+			if (E.value->is_open() && !notified_open.has(E.key)) {
+				_on_channel_open(E.key);
+			}
+		}
+	}
+	if (peer.is_valid()) {
+		if (peer->get_connection_status() != MultiplayerPeer::CONNECTION_DISCONNECTED) {
+			peer->poll();
+		}
+		if (peer.is_valid() && peer->get_connection_status() == MultiplayerPeer::CONNECTION_DISCONNECTED && !is_host && session_emitted) {
+			FakePeerEntry host_entry;
+			if (map.lookup_signal(1, host_entry)) {
+				emit_signal("peer_link_down", String(host_entry.fake_ip), host_entry.fake_port, 1);
+			}
+			close();
+			return;
+		}
+	}
+	if (ice_deadline_msec > 0 && OS::get_singleton()->get_ticks_msec() >= ice_deadline_msec) {
+		ice_deadline_msec = 0;
+		for (KeyValue<int, Ref<WebRTCLink>> &E : links) {
+			if (E.value.is_valid() && E.value->get_mode() != WebRTCLink::MODE_RELAY && !E.value->is_open()) {
+				E.value->set_mode(WebRTCLink::MODE_RELAY);
+				map.set_relay(E.key, true);
+				emit_signal("using_relay", E.key);
+			}
+		}
+		_maybe_create_enet();
+		_maybe_emit_ready();
+	}
+}
+
+bool WebRTCEnetSession::is_in_room() const {
+	return session_emitted || peer.is_valid();
+}
+
+Signal WebRTCEnetSession::create_room(const String &p_name, int p_max_clients, const String &p_password, bool p_hidden, const PackedStringArray &p_tags) {
+	ERR_FAIL_COND_V_MSG(pending != OP_NONE, Signal(this, "failed"), "A session operation is already in progress.");
+	if (is_in_room()) {
+		_fail("already in a room");
+		return Signal(this, "failed");
+	}
+	const String name = GamesEnetWebrtcProtocol::strip_controls(p_name);
+	if (!GamesEnetWebrtcProtocol::is_valid_room_name(name) || !GamesEnetWebrtcProtocol::is_valid_password(p_password)) {
+		_fail("invalid room fields");
+		return Signal(this, "failed");
+	}
+	pending = OP_CREATE;
+	session_emitted = false;
+	is_host = true;
+	host_transport_ready = true;
+	_ensure_process();
+
+	Dictionary payload;
+	payload["name"] = name;
+	payload["max"] = GamesEnetWebrtcProtocol::clamp_max_clients(p_max_clients);
+	if (!p_password.is_empty()) {
+		payload["password"] = p_password;
+	}
+	payload["hidden"] = p_hidden;
+	PackedStringArray tags;
+	for (int i = 0; i < p_tags.size() && tags.size() < GamesEnetWebrtcProtocol::MAX_TAGS; i++) {
+		const String t = p_tags[i];
+		if (GamesEnetWebrtcProtocol::is_valid_game_id(t) && t.length() <= GamesEnetWebrtcProtocol::MAX_TAG_LEN) {
+			tags.push_back(t);
+		}
+	}
+	payload["tags"] = tags;
+	payload["force_relay"] = force_relay;
+
+	if (signal_client->is_open()) {
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_CREATE, payload);
+	} else {
+		set_meta("_pending_create", payload);
+		signal_client->connect_to_signal();
+	}
+	return Signal(this, "session_ready");
+}
+
+Signal WebRTCEnetSession::join_room(const String &p_room_code, const String &p_password, const String &p_display_name) {
+	ERR_FAIL_COND_V_MSG(pending != OP_NONE, Signal(this, "failed"), "A session operation is already in progress.");
+	if (is_in_room()) {
+		_fail("already in a room");
+		return Signal(this, "failed");
+	}
+	if (!GamesEnetWebrtcProtocol::is_valid_room_code(p_room_code) || !GamesEnetWebrtcProtocol::is_valid_password(p_password)) {
+		_fail("invalid join fields");
+		return Signal(this, "failed");
+	}
+	pending = OP_JOIN;
+	session_emitted = false;
+	is_host = false;
+	host_transport_ready = false;
+	room_code = p_room_code;
+	_ensure_process();
+
+	Dictionary payload;
+	payload["room_code"] = p_room_code;
+	if (!p_password.is_empty()) {
+		payload["password"] = p_password;
+	}
+	payload["force_relay"] = force_relay;
+	const String display = GamesEnetWebrtcProtocol::strip_controls(p_display_name);
+	if (GamesEnetWebrtcProtocol::is_valid_room_name(display)) {
+		payload["name"] = display;
+	}
+
+	if (signal_client->is_open()) {
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_JOIN, payload);
+	} else {
+		set_meta("_pending_join", payload);
+		signal_client->connect_to_signal();
+	}
+	return Signal(this, "session_ready");
+}
+
+Signal WebRTCEnetSession::list_rooms() {
+	_ensure_process();
+	if (signal_client->is_open()) {
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_LIST, Dictionary());
+	} else {
+		set_meta("_pending_list", true);
+		signal_client->connect_to_signal();
+	}
+	return Signal(this, "rooms_listed");
+}
+
+Error WebRTCEnetSession::leave() {
+	const bool notify = signal_client.is_valid() && signal_client->is_open() && is_in_room();
+	if (notify) {
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_LEAVE, Dictionary());
+	}
+	session_emitted = false;
+	pending = OP_NONE;
+	close();
+	return notify ? OK : ERR_UNCONFIGURED;
+}
+
+Error WebRTCEnetSession::seal() {
+	ERR_FAIL_COND_V(!is_host || !signal_client.is_valid() || !signal_client->is_open(), ERR_UNCONFIGURED);
+	return signal_client->send_message(GamesEnetWebrtcProtocol::MSG_SEAL, Dictionary());
+}
+
+Error WebRTCEnetSession::kick(int p_signal_id) {
+	ERR_FAIL_COND_V(!is_host || !signal_client.is_valid() || !signal_client->is_open(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(!GamesEnetWebrtcProtocol::is_valid_signal_id(p_signal_id) || p_signal_id == local_signal_id, ERR_INVALID_PARAMETER);
+	Dictionary payload;
+	payload["signal_id"] = p_signal_id;
+	return signal_client->send_message(GamesEnetWebrtcProtocol::MSG_KICK, payload, p_signal_id);
+}
+
+Ref<ENetMultiplayerPeer> WebRTCEnetSession::get_peer() const {
+	return peer;
+}
+
+void WebRTCEnetSession::_on_signal_connected() {
+	if (has_meta("_pending_create")) {
+		Dictionary payload = get_meta("_pending_create");
+		remove_meta("_pending_create");
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_CREATE, payload);
+	}
+	if (has_meta("_pending_join")) {
+		Dictionary payload = get_meta("_pending_join");
+		remove_meta("_pending_join");
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_JOIN, payload);
+	}
+	if (has_meta("_pending_list")) {
+		remove_meta("_pending_list");
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_LIST, Dictionary());
+	}
+}
+
+void WebRTCEnetSession::_on_signal_disconnected() {
+	if (pending != OP_NONE) {
+		_fail("signal disconnected");
+	}
+	if (is_in_room()) {
+		FakePeerEntry host_entry;
+		if (!is_host && map.lookup_signal(1, host_entry)) {
+			emit_signal("peer_link_down", String(host_entry.fake_ip), host_entry.fake_port, 1);
+		}
+		close();
+	}
+}
+
+void WebRTCEnetSession::_on_signal_message(int p_type, int p_id, Dictionary p_data) {
+	using namespace GamesEnetWebrtcProtocol;
+	if (!payload_within_limits(p_type, p_data)) {
+		return;
+	}
+	switch (p_type) {
+		case MSG_HELLO:
+			_handle_hello(p_data);
+			break;
+		case MSG_PEER_INFO:
+			_handle_peer_info(p_data);
+			break;
+		case MSG_PEER_CONNECT:
+			_handle_peer_info(p_data);
+			break;
+		case MSG_PEER_DISCONNECT: {
+			const int sid = int(p_data.get("signal_id", p_id));
+			FakePeerEntry entry;
+			if (map.lookup_signal(sid, entry)) {
+				emit_signal("peer_link_down", String(entry.fake_ip), entry.fake_port, sid);
+			}
+			if (links.has(sid)) {
+				map.set_link(sid, nullptr);
+				links[sid]->close();
+				links.erase(sid);
+			}
+			map.remove_signal(sid);
+		} break;
+		case MSG_OFFER:
+		case MSG_ANSWER: {
+			const int sid = int(p_data.get("signal_id", p_id));
+			if (!is_valid_signal_id(sid) || !links.has(sid)) {
+				break;
+			}
+			links[sid]->set_remote_description(String(p_data.get("sdp_type", p_type == MSG_OFFER ? "offer" : "answer")), String(p_data.get("sdp", "")));
+		} break;
+		case MSG_CANDIDATE: {
+			const int sid = int(p_data.get("signal_id", p_id));
+			if (!is_valid_signal_id(sid) || !links.has(sid)) {
+				break;
+			}
+			links[sid]->add_ice_candidate(String(p_data.get("mid", p_data.get("media", "0"))), int(p_data.get("index", 0)), String(p_data.get("candidate", "")));
+		} break;
+		case MSG_USE_RELAY: {
+			const int sid = int(p_data.get("signal_id", p_id));
+			FakePeerEntry relay_entry;
+			if (!is_valid_signal_id(sid) || !map.lookup_signal(sid, relay_entry)) {
+				break;
+			}
+			if (links.has(sid)) {
+				links[sid]->set_mode(WebRTCLink::MODE_RELAY);
+			}
+			map.set_relay(sid, true);
+			emit_signal("using_relay", sid);
+			if (sid == 1) {
+				host_transport_ready = true;
+			}
+			_maybe_create_enet();
+			_maybe_emit_ready();
+		} break;
+		case MSG_RELAY_DATAGRAM: {
+			int from = 0;
+			Vector<uint8_t> payload;
+			if (!RelayClient::decode_datagram(p_data, from, payload)) {
+				break;
+			}
+			if (from == 0) {
+				from = p_id;
+			}
+			FakePeerEntry entry;
+			if (map.lookup_signal(from, entry)) {
+				map.push_inbound(payload, entry.fake_ip, entry.fake_port);
+			}
+		} break;
+		case MSG_LIST: {
+			cached_rooms = GamesEnetWebrtcProtocol::sanitize_room_list(p_data.get("rooms", Array()));
+			emit_signal("rooms_listed", cached_rooms);
+		} break;
+		case MSG_ICE_CONFIG: {
+			ice_servers = GamesEnetWebrtcProtocol::sanitize_ice_servers(p_data.get("ice_servers", Array()));
+		} break;
+		case MSG_ERROR: {
+			String msg = GamesEnetWebrtcProtocol::strip_controls(String(p_data.get("message", "signal error")));
+			if (msg.length() > 256) {
+				msg = msg.substr(0, 256);
+			}
+			if (msg.is_empty()) {
+				msg = "signal error";
+			}
+			_fail(msg);
+		} break;
+		case MSG_PING:
+
+			break;
+		default:
+			break;
+	}
+}
+
+void WebRTCEnetSession::_handle_hello(const Dictionary &p_data) {
+	local_signal_id = int(p_data.get("signal_id", 0));
+	local_fake_ip = String(p_data.get("fake_ip", ""));
+	local_fake_port = int(p_data.get("fake_port", 1));
+	room_code = String(p_data.get("room_code", room_code));
+	if (!GamesEnetWebrtcProtocol::is_valid_signal_id(local_signal_id) || !GamesEnetWebrtcProtocol::is_valid_fake_ip(local_fake_ip) || !GamesEnetWebrtcProtocol::is_valid_fake_port(local_fake_port) || !GamesEnetWebrtcProtocol::is_valid_room_code(room_code)) {
+		_fail("invalid HELLO");
+		return;
+	}
+	ice_servers = GamesEnetWebrtcProtocol::sanitize_ice_servers(p_data.get("ice_servers", Array()));
+
+	FakePeerEntry self;
+	self.signal_id = local_signal_id;
+	self.fake_ip = IPAddress(local_fake_ip);
+	self.fake_port = (uint16_t)local_fake_port;
+	self.role = is_host ? "host" : "joiner";
+	map.add_peer(self);
+
+	if (force_relay) {
+		ice_deadline_msec = 0;
+	} else {
+		ice_deadline_msec = OS::get_singleton()->get_ticks_msec() + ice_timeout_msec;
+	}
+
+	if (is_host) {
+		_maybe_create_enet();
+		_maybe_emit_ready();
+	}
+}
+
+void WebRTCEnetSession::_handle_peer_info(const Dictionary &p_data) {
+	const int sid = int(p_data.get("signal_id", 0));
+	if (sid == 0 || sid == local_signal_id) {
+		return;
+	}
+	const String fip = String(p_data.get("fake_ip", ""));
+	const int fport = int(p_data.get("fake_port", 1));
+	if (!GamesEnetWebrtcProtocol::is_valid_signal_id(sid) || !GamesEnetWebrtcProtocol::is_valid_fake_ip(fip) || !GamesEnetWebrtcProtocol::is_valid_fake_port(fport)) {
+		return;
+	}
+	FakePeerEntry entry;
+	entry.signal_id = sid;
+	entry.fake_ip = IPAddress(fip);
+	entry.fake_port = (uint16_t)fport;
+	const String role = String(p_data.get("role", ""));
+	entry.role = GamesEnetWebrtcProtocol::is_valid_role(role) ? role : String();
+	entry.name = GamesEnetWebrtcProtocol::strip_controls(String(p_data.get("name", "")));
+	map.add_peer(entry);
+
+	if (!GamesEnetWebrtcProtocol::is_star_pair(local_signal_id, sid)) {
+		return;
+	}
+
+	const bool we_offer = local_signal_id < sid;
+	if (force_relay) {
+		entry.relay = true;
+		map.set_relay(sid, true);
+		Ref<WebRTCLink> link;
+		link.instantiate();
+		link->set_mode(WebRTCLink::MODE_RELAY);
+		links[sid] = link;
+		if (sid == 1) {
+			host_transport_ready = true;
+		}
+		notified_open.insert(sid);
+		emit_signal("using_relay", sid);
+		emit_signal("peer_link_up", String(entry.fake_ip), entry.fake_port, sid);
+		_maybe_create_enet();
+		_maybe_emit_ready();
+		return;
+	}
+
+	_ensure_link(sid, entry.fake_ip, entry.fake_port, we_offer);
+}
+
+Ref<WebRTCLink> WebRTCEnetSession::_ensure_link(int p_signal_id, const IPAddress &p_ip, uint16_t p_port, bool p_offerer) {
+	if (links.has(p_signal_id)) {
+		return links[p_signal_id];
+	}
+	Ref<WebRTCLink> link;
+	link.instantiate();
+	link->connect("local_description", callable_mp(this, &WebRTCEnetSession::_on_local_description).bind(p_signal_id));
+	link->connect("local_candidate", callable_mp(this, &WebRTCEnetSession::_on_local_candidate).bind(p_signal_id));
+	link->connect("using_turn", callable_mp(this, &WebRTCEnetSession::_on_using_turn).bind(p_signal_id));
+	link->setup(p_signal_id, p_ip, p_port, &map, p_offerer, ice_servers);
+	links[p_signal_id] = link;
+	map.set_link(p_signal_id, link.ptr());
+	return link;
+}
+
+void WebRTCEnetSession::_on_local_description(const String &p_type, const String &p_sdp, int p_signal_id) {
+	Dictionary payload;
+	payload["sdp"] = p_sdp;
+	payload["sdp_type"] = p_type;
+	const int msg = p_type == "offer" ? GamesEnetWebrtcProtocol::MSG_OFFER : GamesEnetWebrtcProtocol::MSG_ANSWER;
+	signal_client->send_message(msg, payload, p_signal_id);
+}
+
+void WebRTCEnetSession::_on_local_candidate(const String &p_media, int p_index, const String &p_name, int p_signal_id) {
+	Dictionary payload;
+	payload["mid"] = p_media;
+	payload["index"] = p_index;
+	payload["candidate"] = p_name;
+	signal_client->send_message(GamesEnetWebrtcProtocol::MSG_CANDIDATE, payload, p_signal_id);
+}
+
+void WebRTCEnetSession::_on_channel_open(int p_signal_id) {
+	if (notified_open.has(p_signal_id)) {
+		return;
+	}
+	notified_open.insert(p_signal_id);
+	FakePeerEntry entry;
+	if (!map.lookup_signal(p_signal_id, entry)) {
+		return;
+	}
+	if (p_signal_id == 1) {
+		host_transport_ready = true;
+	}
+	signal_client->send_message(GamesEnetWebrtcProtocol::MSG_PEER_READY, Dictionary(), p_signal_id);
+	emit_signal("peer_link_up", String(entry.fake_ip), entry.fake_port, p_signal_id);
+	_maybe_create_enet();
+	_maybe_emit_ready();
+}
+
+void WebRTCEnetSession::_on_using_turn(int p_signal_id) {
+	emit_signal("using_turn", p_signal_id);
+}
+
+void WebRTCEnetSession::_maybe_create_enet() {
+	if (peer.is_valid()) {
+		return;
+	}
+	if (local_fake_ip.is_empty()) {
+		return;
+	}
+	if (!is_host && !host_transport_ready) {
+		return;
+	}
+
+	peer.instantiate();
+	peer->set_bind_ip(IPAddress(local_fake_ip));
+	ENetWebRTCSocketFactory::Guard guard(&map, this);
+	Error err;
+	if (is_host) {
+		err = peer->create_server(local_fake_port, GamesEnetWebrtcProtocol::ADVERTISED_ROOM_CAP);
+	} else {
+		err = peer->create_client("10.66.0.1", 1, 0, 0, 0, local_fake_port);
+	}
+	if (err != OK) {
+		peer.unref();
+		_fail("failed to create ENet peer");
+	}
+}
+
+void WebRTCEnetSession::_maybe_emit_ready() {
+	if (session_emitted || peer.is_null()) {
+		return;
+	}
+	if (!is_host && !host_transport_ready) {
+		return;
+	}
+	session_emitted = true;
+	pending = OP_NONE;
+	emit_signal("session_ready", local_fake_ip, local_fake_port, room_code);
+}
+
+Error WebRTCEnetSession::send_datagram(const IPAddress &p_ip, uint16_t p_port, const uint8_t *p_buffer, int p_len) {
+	ERR_FAIL_COND_V(p_buffer == nullptr || p_len <= 0 || p_len > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES, ERR_INVALID_PARAMETER);
+	FakePeerEntry entry;
+	if (!map.lookup_addr(p_ip, p_port, entry)) {
+		return ERR_BUSY;
+	}
+	if (!GamesEnetWebrtcProtocol::is_star_pair(local_signal_id, entry.signal_id)) {
+		return ERR_BUSY;
+	}
+	if (entry.link && entry.link->is_open() && entry.link->get_mode() != WebRTCLink::MODE_RELAY) {
+		return entry.link->send(p_buffer, p_len);
+	}
+	if (entry.relay || force_relay || (entry.link && entry.link->get_mode() == WebRTCLink::MODE_RELAY)) {
+		return relay.send_datagram(entry.signal_id, p_buffer, p_len);
+	}
+	if (entry.link) {
+		const Error e = entry.link->send(p_buffer, p_len);
+		if (e == OK) {
+			return OK;
+		}
+	}
+	return relay.send_datagram(entry.signal_id, p_buffer, p_len);
+}
+
+void WebRTCEnetSession::close() {
+	if (signal_client.is_valid() && signal_client->is_open() && (session_emitted || pending != OP_NONE)) {
+		signal_client->send_message(GamesEnetWebrtcProtocol::MSG_LEAVE, Dictionary());
+	}
+	pending = OP_NONE;
+	ice_deadline_msec = 0;
+	session_emitted = false;
+	host_transport_ready = false;
+	is_host = false;
+	local_fake_ip = String();
+	local_fake_port = 1;
+	local_signal_id = 0;
+	room_code = String();
+	last_ping_msec = 0;
+	for (KeyValue<int, Ref<WebRTCLink>> &E : links) {
+		map.set_link(E.key, nullptr);
+		if (E.value.is_valid()) {
+			E.value->close();
+		}
+	}
+	links.clear();
+	notified_open.clear();
+	map.clear();
+	if (peer.is_valid()) {
+		peer->close();
+		peer.unref();
+	}
+	if (signal_client.is_valid()) {
+		signal_client->close();
+	}
+	set_process(false);
+}

--- a/modules/games_enet_webrtc/webrtc_enet_session.h
+++ b/modules/games_enet_webrtc/webrtc_enet_session.h
@@ -1,0 +1,123 @@
+/**************************************************************************/
+/*  webrtc_enet_session.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "fake_address_map.h"
+#include "relay_client.h"
+#include "signal_client.h"
+#include "webrtc_link.h"
+
+#include "core/templates/hash_set.h"
+#include "modules/enet/enet_multiplayer_peer.h"
+#include "scene/main/node.h"
+
+class WebRTCEnetSession : public Node {
+	GDCLASS(WebRTCEnetSession, Node);
+
+	enum PendingOp {
+		OP_NONE,
+		OP_CREATE,
+		OP_JOIN,
+		OP_LIST,
+	};
+
+	Ref<SignalClient> signal_client;
+	RelayClient relay;
+	FakeAddressMap map;
+	HashMap<int, Ref<WebRTCLink>> links;
+	Ref<ENetMultiplayerPeer> peer;
+
+	String signal_url;
+	String game_id;
+	String auth_token;
+	String room_code;
+	String local_fake_ip;
+	int local_fake_port = 1;
+	int local_signal_id = 0;
+	bool is_host = false;
+	bool force_relay = false;
+	int ice_timeout_msec = 8000;
+	uint64_t ice_deadline_msec = 0;
+	PendingOp pending = OP_NONE;
+	Array ice_servers;
+	Array cached_rooms;
+	bool session_emitted = false;
+	bool host_transport_ready = false;
+	uint64_t last_ping_msec = 0;
+
+	void _on_signal_connected();
+	void _on_signal_disconnected();
+	void _on_signal_message(int p_type, int p_id, Dictionary p_data);
+	void _on_local_description(const String &p_type, const String &p_sdp, int p_signal_id);
+	void _on_local_candidate(const String &p_media, int p_index, const String &p_name, int p_signal_id);
+	void _on_channel_open(int p_signal_id);
+	void _on_using_turn(int p_signal_id);
+	HashSet<int> notified_open;
+
+	void _ensure_process();
+	void _poll();
+	void _fail(const String &p_reason);
+	void _handle_hello(const Dictionary &p_data);
+	void _handle_peer_info(const Dictionary &p_data);
+	void _maybe_create_enet();
+	void _maybe_emit_ready();
+	Ref<WebRTCLink> _ensure_link(int p_signal_id, const IPAddress &p_ip, uint16_t p_port, bool p_offerer);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	Error configure(const String &p_signal_url, const String &p_game_id, const String &p_auth_token);
+	Signal create_room(const String &p_name, int p_max_clients = 8, const String &p_password = String(), bool p_hidden = false, const PackedStringArray &p_tags = PackedStringArray());
+	Signal join_room(const String &p_room_code, const String &p_password = String(), const String &p_display_name = String());
+	Signal list_rooms();
+	Error leave();
+	Error seal();
+	Error kick(int p_signal_id);
+	Ref<ENetMultiplayerPeer> get_peer() const;
+	void close();
+	bool is_in_room() const;
+
+	void set_force_relay(bool p_enable);
+	bool get_force_relay() const { return force_relay; }
+	void set_ice_timeout_msec(int p_msec);
+	int get_ice_timeout_msec() const { return ice_timeout_msec; }
+
+	String get_room_code() const { return room_code; }
+	String get_local_fake_ip() const { return local_fake_ip; }
+	int get_local_fake_port() const { return local_fake_port; }
+	int get_local_signal_id() const { return local_signal_id; }
+
+	Error send_datagram(const IPAddress &p_ip, uint16_t p_port, const uint8_t *p_buffer, int p_len);
+
+	WebRTCEnetSession();
+	~WebRTCEnetSession();
+};

--- a/modules/games_enet_webrtc/webrtc_link.cpp
+++ b/modules/games_enet_webrtc/webrtc_link.cpp
@@ -1,0 +1,167 @@
+/**************************************************************************/
+/*  webrtc_link.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "webrtc_link.h"
+
+#include "fake_address_map.h"
+#include "protocol.h"
+
+#include <cstring>
+
+void WebRTCLink::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("local_description", PropertyInfo(Variant::STRING, "type"), PropertyInfo(Variant::STRING, "sdp")));
+	ADD_SIGNAL(MethodInfo("local_candidate", PropertyInfo(Variant::STRING, "media"), PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("channel_open"));
+	ADD_SIGNAL(MethodInfo("using_turn"));
+}
+
+void WebRTCLink::setup(int p_remote_signal_id, const IPAddress &p_fake_ip, uint16_t p_fake_port, FakeAddressMap *p_map, bool p_offerer, const Array &p_ice_servers) {
+	remote_signal_id = p_remote_signal_id;
+	remote_fake_ip = p_fake_ip;
+	remote_fake_port = p_fake_port;
+	map = p_map;
+	offerer = p_offerer;
+
+	pc = Ref<WebRTCPeerConnection>(WebRTCPeerConnection::create());
+	ERR_FAIL_COND(pc.is_null());
+
+	pc->connect("session_description_created", callable_mp(this, &WebRTCLink::_on_session_description));
+	pc->connect("ice_candidate_created", callable_mp(this, &WebRTCLink::_on_ice_candidate));
+
+	Dictionary config;
+	if (!p_ice_servers.is_empty()) {
+		config["iceServers"] = p_ice_servers;
+	}
+	pc->initialize(config);
+
+	Dictionary opts;
+	opts["negotiated"] = true;
+	opts["id"] = 1;
+	opts["ordered"] = false;
+	opts["maxRetransmits"] = 0;
+	channel = pc->create_data_channel("enet", opts);
+	if (channel.is_valid()) {
+		channel->set_write_mode(WebRTCDataChannel::WRITE_MODE_BINARY);
+	}
+
+	if (offerer) {
+		pc->create_offer();
+	}
+}
+
+void WebRTCLink::set_mode(Mode p_mode) {
+	mode = p_mode;
+}
+
+void WebRTCLink::_on_session_description(const String &p_type, const String &p_sdp) {
+	if (pc.is_valid()) {
+		pc->set_local_description(p_type, p_sdp);
+	}
+	emit_signal("local_description", p_type, p_sdp);
+}
+
+void WebRTCLink::_on_ice_candidate(const String &p_media, int p_index, const String &p_name) {
+	if (p_name.contains("typ relay") && mode != MODE_RELAY) {
+		mode = MODE_TURN;
+		emit_signal("using_turn");
+	}
+	emit_signal("local_candidate", p_media, p_index, p_name);
+}
+
+void WebRTCLink::set_remote_description(const String &p_type, const String &p_sdp) {
+	ERR_FAIL_COND(pc.is_null());
+	pc->set_remote_description(p_type, p_sdp);
+}
+
+void WebRTCLink::add_ice_candidate(const String &p_media, int p_index, const String &p_name) {
+	ERR_FAIL_COND(pc.is_null());
+	pc->add_ice_candidate(p_media, p_index, p_name);
+}
+
+bool WebRTCLink::is_open() const {
+	if (mode == MODE_RELAY) {
+		return true;
+	}
+	return channel.is_valid() && channel->get_ready_state() == WebRTCDataChannel::STATE_OPEN;
+}
+
+Error WebRTCLink::send(const uint8_t *p_buffer, int p_len) {
+	ERR_FAIL_NULL_V(p_buffer, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_len <= 0 || p_len > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES, ERR_INVALID_PARAMETER);
+	if (mode == MODE_RELAY || channel.is_null() || channel->get_ready_state() != WebRTCDataChannel::STATE_OPEN) {
+		return ERR_UNAVAILABLE;
+	}
+	return channel->put_packet(p_buffer, p_len);
+}
+
+void WebRTCLink::_drain_channel() {
+	if (channel.is_null() || map == nullptr) {
+		return;
+	}
+	channel->poll();
+	int n = 0;
+	while (channel->get_available_packet_count() > 0 && n < 64) {
+		n++;
+		const uint8_t *buf = nullptr;
+		int size = 0;
+		if (channel->get_packet(&buf, size) != OK || buf == nullptr || size <= 0) {
+			break;
+		}
+		if (size > GamesEnetWebrtcProtocol::MAX_RELAY_BYTES) {
+			continue;
+		}
+		Vector<uint8_t> data;
+		data.resize(size);
+		memcpy(data.ptrw(), buf, size);
+		map->push_inbound(data, remote_fake_ip, remote_fake_port);
+	}
+}
+
+void WebRTCLink::poll() {
+	if (pc.is_valid()) {
+		pc->poll();
+	}
+	if (channel.is_valid()) {
+		const WebRTCDataChannel::ChannelState st = channel->get_ready_state();
+		if (st == WebRTCDataChannel::STATE_OPEN) {
+			_drain_channel();
+		}
+	}
+}
+
+void WebRTCLink::close() {
+	if (channel.is_valid()) {
+		channel->close();
+		channel.unref();
+	}
+	if (pc.is_valid()) {
+		pc->close();
+		pc.unref();
+	}
+}

--- a/modules/games_enet_webrtc/webrtc_link.h
+++ b/modules/games_enet_webrtc/webrtc_link.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  webrtc_link.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/ip_address.h"
+#include "core/object/ref_counted.h"
+#include "core/variant/dictionary.h"
+#include "modules/webrtc/webrtc_data_channel.h"
+#include "modules/webrtc/webrtc_peer_connection.h"
+
+class FakeAddressMap;
+
+class WebRTCLink : public RefCounted {
+	GDCLASS(WebRTCLink, RefCounted);
+
+public:
+	enum Mode {
+		MODE_P2P,
+		MODE_TURN,
+		MODE_RELAY,
+	};
+
+private:
+	int remote_signal_id = 0;
+	IPAddress remote_fake_ip;
+	uint16_t remote_fake_port = 1;
+	bool offerer = false;
+	Mode mode = MODE_P2P;
+	FakeAddressMap *map = nullptr;
+
+	Ref<WebRTCPeerConnection> pc;
+	Ref<WebRTCDataChannel> channel;
+
+	void _on_session_description(const String &p_type, const String &p_sdp);
+	void _on_ice_candidate(const String &p_media, int p_index, const String &p_name);
+	void _drain_channel();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void setup(int p_remote_signal_id, const IPAddress &p_fake_ip, uint16_t p_fake_port, FakeAddressMap *p_map, bool p_offerer, const Array &p_ice_servers);
+	void set_mode(Mode p_mode);
+	Mode get_mode() const { return mode; }
+
+	void set_remote_description(const String &p_type, const String &p_sdp);
+	void add_ice_candidate(const String &p_media, int p_index, const String &p_name);
+
+	bool is_open() const;
+	bool has_peer_connection() const { return pc.is_valid(); }
+	Error send(const uint8_t *p_buffer, int p_len);
+	void poll();
+	void close();
+
+	int get_remote_signal_id() const { return remote_signal_id; }
+	IPAddress get_remote_fake_ip() const { return remote_fake_ip; }
+	uint16_t get_remote_fake_port() const { return remote_fake_port; }
+};

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -234,8 +234,12 @@ Files extracted from upstream source:
 - All `.c` files in the main directory (except `unix.c` and `win32.c`)
 - The `include/enet/` folder as `enet/` (except `unix.h` and `win32.h`)
 - `LICENSE` file
-- Added 3 files `enet_godot.cpp`, `enet/enet_godot.h`, and `enet/enet_godot_ext.h`,
-  providing ENet socket implementation using Godot classes, allowing IPv6 and DTLS.
+- Added 4 files `enet_godot.cpp`, `enet/enet_godot.h`, `enet/enet_godot_ext.h`,
+  and `enet/enet_godot_socket.h`, providing ENet socket implementation using
+  Godot classes, allowing IPv6 and DTLS. `enet_godot_socket.h` exposes
+  `ENetGodotSocket` and a thread-local `enet_set_socket_create_fn` hook so a
+  module can install a custom backend for one `enet_host_create` without
+  changing default UDP/DTLS sockets.
 
 Patches:
 

--- a/thirdparty/enet/enet/enet_godot_socket.h
+++ b/thirdparty/enet/enet/enet_godot_socket.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  enet_godot_socket.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_list.h"
+#include "core/io/ip_address.h"
+
+/// Abstract ENet interface for UDP/DTLS/custom backends.
+/// Intentionally does not include enet.h (Winsock) so module code can include this
+/// without breaking Object/ConnectFlags.
+class ENetGodotSocket {
+public:
+	virtual Error bind(IPAddress p_ip, uint16_t p_port) = 0;
+	virtual Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) = 0;
+	virtual Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IPAddress p_ip, uint16_t p_port) = 0;
+	virtual Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddress &r_ip, uint16_t &r_port) = 0;
+	virtual int set_option(int p_option, int p_value) = 0;
+	virtual void close() = 0;
+	virtual void set_refuse_new_connections(bool p_enable) {} /* Only used by dtls server */
+	virtual bool can_upgrade() { return false; } /* Only true in ENetUDP */
+	virtual ~ENetGodotSocket() {}
+};
+
+typedef ENetGodotSocket *(*ENetSocketCreateFn)();
+
+/// Thread-local socket factory. nullptr restores the default UDP socket.
+/// Does not change behavior unless a caller installs a function for the
+/// duration of one enet_host_create.
+void enet_set_socket_create_fn(ENetSocketCreateFn p_fn);
+ENetSocketCreateFn enet_get_socket_create_fn();

--- a/thirdparty/enet/enet_godot.cpp
+++ b/thirdparty/enet/enet_godot.cpp
@@ -42,20 +42,17 @@
 
 // This must be last for windows to compile (tested with MinGW)
 #include "enet/enet.h"
+#include "enet/enet_godot_socket.h"
 
-/// Abstract ENet interface for UDP/DTLS.
-class ENetGodotSocket {
-public:
-	virtual Error bind(IPAddress p_ip, uint16_t p_port) = 0;
-	virtual Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) = 0;
-	virtual Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IPAddress p_ip, uint16_t p_port) = 0;
-	virtual Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddress &r_ip, uint16_t &r_port) = 0;
-	virtual int set_option(ENetSocketOption p_option, int p_value) = 0;
-	virtual void close() = 0;
-	virtual void set_refuse_new_connections(bool p_enable) {} /* Only used by dtls server */
-	virtual bool can_upgrade() { return false; } /* Only true in ENetUDP */
-	virtual ~ENetGodotSocket() {}
-};
+thread_local ENetSocketCreateFn _enet_socket_create_fn = nullptr;
+
+void enet_set_socket_create_fn(ENetSocketCreateFn p_fn) {
+	_enet_socket_create_fn = p_fn;
+}
+
+ENetSocketCreateFn enet_get_socket_create_fn() {
+	return _enet_socket_create_fn;
+}
 
 class ENetDTLSClient;
 class ENetDTLSServer;
@@ -111,7 +108,7 @@ public:
 		return sock->recvfrom(p_buffer, p_len, r_read, r_ip, r_port);
 	}
 
-	int set_option(ENetSocketOption p_option, int p_value) {
+	int set_option(int p_option, int p_value) {
 		switch (p_option) {
 			case ENET_SOCKOPT_NONBLOCK: {
 				sock->set_blocking_enabled(p_value ? false : true);
@@ -244,7 +241,7 @@ public:
 		return err;
 	}
 
-	int set_option(ENetSocketOption p_option, int p_value) {
+	int set_option(int p_option, int p_value) {
 		return -1;
 	}
 
@@ -380,7 +377,7 @@ public:
 		return err; // OK, ERR_BUSY, or possibly an error.
 	}
 
-	int set_option(ENetSocketOption p_option, int p_value) {
+	int set_option(int p_option, int p_value) {
 		return -1;
 	}
 
@@ -439,6 +436,12 @@ int enet_address_get_host(const ENetAddress *address, char *name, size_t nameLen
 }
 
 ENetSocket enet_socket_create(ENetSocketType type) {
+	if (_enet_socket_create_fn) {
+		ENetGodotSocket *custom = _enet_socket_create_fn();
+		if (custom) {
+			return custom;
+		}
+	}
 	ENetUDP *socket = memnew(ENetUDP);
 
 	return socket;


### PR DESCRIPTION
## Summary
- Add the `games_enet_webrtc` module so existing `ENetMultiplayerPeer` games can carry ENet datagrams over WebRTC DataChannels (with a WSS relay fallback).
- Extend thirdparty ENet with a thread-local `ENetGodotSocket` factory used only for the duration of one `enet_host_create`. LAN UDP ENet is unchanged.
- Example signaling, TURN, and module tests live in companion repos: [blazium-signal](https://github.com/blazium-games/blazium-signal), [blazium-turn](https://github.com/blazium-games/blazium-turn), [games_enet_webrtc_module_tests](https://github.com/blazium-games/games_enet_webrtc_module_tests).

## Test plan
- [x] `scons platform=windows target=editor tests=yes`
- [x] `bin/blazium --headless --test --test-case=*[GamesEnetWebrtc]*` (24 cases, 458 assertions)
- [x] `bin/blazium --doctool --headless` (module XML aligned)
- [x] `pre-commit run` on changed files
- [x] Live GDScript suite against local blazium-signal with `SIGNAL_LIVE=1`