### PR TITLE
Allow hiding the main window via project setting

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1604,6 +1604,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/size/extend_to_title", false);
 	GLOBAL_DEF("display/window/size/no_focus", false);
 	GLOBAL_DEF("display/window/size/sharp_corners", false);
+	GLOBAL_DEF("display/window/size/allow_hide_main_window", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_width_override", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"), 0); // 8K resolution
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_height_override", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"), 0); // 8K resolution

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2678,6 +2678,11 @@
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].
 		</member>
+		<member name="display/window/size/allow_hide_main_window" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], allows hiding the main (root) window with [method Window.hide] or [method Window.set_visible]. When [code]false[/code] or unset, changing visibility of the main window is declined.
+			Enable this only for tools that need system-tray hide. Games should leave it off.
+			[b]Note:[/b] Hiding keeps the native window alive; it does not destroy [constant DisplayServer.MAIN_WINDOW_ID].
+		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and Web.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2679,7 +2679,7 @@
 			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].
 		</member>
 		<member name="display/window/size/allow_hide_main_window" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows hiding the main (root) window with [method Window.hide] or [method Window.set_visible]. When [code]false[/code] or unset, changing visibility of the main window is declined.
+			If [code]true[/code], allows hiding the main (root) window with [method Window.hide] or [member Window.visible]. When [code]false[/code] or unset, changing visibility of the main window is declined.
 			Enable this only for tools that need system-tray hide. Games should leave it off.
 			[b]Note:[/b] Hiding keeps the native window alive; it does not destroy [constant DisplayServer.MAIN_WINDOW_ID].
 		</member>

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -818,6 +818,32 @@ void DisplayServerWayland::show_window(WindowID p_window_id) {
 	}
 }
 
+void DisplayServerWayland::hide_window(WindowID p_window_id) {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	ERR_FAIL_COND(!windows.has(p_window_id));
+	WindowData &wd = windows[p_window_id];
+	if (!wd.visible) {
+		return;
+	}
+
+#ifdef VULKAN_ENABLED
+	if (rendering_device) {
+		rendering_device->screen_free(p_window_id);
+	}
+	if (rendering_context) {
+		rendering_context->window_destroy(p_window_id);
+	}
+#endif
+#ifdef GLES3_ENABLED
+	if (egl_manager) {
+		egl_manager->window_destroy(p_window_id);
+	}
+#endif
+	wayland_thread.window_destroy(p_window_id);
+	wd.visible = false;
+}
+
 void DisplayServerWayland::delete_sub_window(WindowID p_window_id) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -248,6 +248,7 @@ public:
 
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
 	virtual void show_window(WindowID p_id) override;
+	virtual void hide_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
 	virtual WindowID window_get_active_popup() const override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1909,6 +1909,15 @@ void DisplayServerX11::show_window(WindowID p_id) {
 	_validate_mode_on_map(p_id);
 }
 
+void DisplayServerX11::hide_window(WindowID p_id) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_id));
+	const WindowData &wd = windows[p_id];
+	XUnmapWindow(x11_display, wd.x11_window);
+	XSync(x11_display, False);
+}
+
 void DisplayServerX11::delete_sub_window(WindowID p_id) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -472,6 +472,7 @@ public:
 
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
 	virtual void show_window(WindowID p_id) override;
+	virtual void hide_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
 	virtual WindowID window_get_active_popup() const override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -358,6 +358,7 @@ public:
 
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
 	virtual void show_window(WindowID p_id) override;
+	virtual void hide_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
 	virtual WindowID window_get_active_popup() const override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1938,6 +1938,12 @@ void DisplayServerMacOS::show_window(WindowID p_id) {
 	}
 }
 
+void DisplayServerMacOS::hide_window(WindowID p_id) {
+	ERR_FAIL_COND(!windows.has(p_id));
+	WindowData &wd = windows[p_id];
+	[wd.window_object orderOut:nil];
+}
+
 void DisplayServerMacOS::delete_sub_window(WindowID p_id) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1713,6 +1713,15 @@ void DisplayServerWindows::show_window(WindowID p_id) {
 	}
 }
 
+void DisplayServerWindows::hide_window(WindowID p_id) {
+	ERR_FAIL_COND(!windows.has(p_id));
+
+	WindowData &wd = windows[p_id];
+	if (wd.hWnd) {
+		ShowWindow(wd.hWnd, SW_HIDE);
+	}
+}
+
 void DisplayServerWindows::delete_sub_window(WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -771,6 +771,7 @@ public:
 
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
 	virtual void show_window(WindowID p_window) override;
+	virtual void hide_window(WindowID p_window) override;
 	virtual void delete_sub_window(WindowID p_window) override;
 
 	virtual WindowID window_get_active_popup() const override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -880,7 +880,30 @@ void Window::set_visible(bool p_visible) {
 		return;
 	}
 
-	ERR_FAIL_NULL_MSG(get_parent(), "Can't change visibility of main window.");
+	if (!get_parent()) {
+		if (!GLOBAL_GET("display/window/size/allow_hide_main_window")) {
+			ERR_FAIL_MSG("Can't change visibility of main window.");
+		}
+
+		visible = p_visible;
+		updating_child_controls = false;
+
+		if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+			if (p_visible) {
+				DisplayServer::get_singleton()->show_window(window_id);
+			} else {
+				DisplayServer::get_singleton()->hide_window(window_id);
+			}
+		}
+
+		if (!visible) {
+			focused = false;
+		}
+		notification(NOTIFICATION_VISIBILITY_CHANGED);
+		emit_signal(SceneStringName(visibility_changed));
+		RS::get_singleton()->viewport_set_active(get_viewport_rid(), visible);
+		return;
+	}
 
 	visible = p_visible;
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -605,6 +605,10 @@ void DisplayServer::show_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }
 
+void DisplayServer::hide_window(WindowID p_id) {
+	ERR_FAIL_MSG("Hiding windows is not supported by this display server.");
+}
+
 void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -424,6 +424,7 @@ public:
 
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID);
 	virtual void show_window(WindowID p_id);
+	virtual void hide_window(WindowID p_id);
 	virtual void delete_sub_window(WindowID p_id);
 
 	virtual WindowID window_get_active_popup() const { return INVALID_WINDOW_ID; }

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -86,6 +86,7 @@ public:
 
 	WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override { return 0; }
 	void show_window(WindowID p_id) override {}
+	void hide_window(WindowID p_id) override {}
 	void delete_sub_window(WindowID p_id) override {}
 
 	WindowID get_window_at_screen_position(const Point2i &p_position) const override { return 0; }


### PR DESCRIPTION
﻿## Summary
- Add `display/window/size/allow_hide_main_window` (default false).
- Root Window.hide/show is allowed only when that flag is set; otherwise the existing decline remains.
- Hide uses DisplayServer (ShowWindow SW_HIDE on Windows) and does not destroy MAIN_WINDOW_ID.

## Test plan
- [ ] Default project: get_window().hide() still errors with the main-window visibility message.
- [ ] With the setting true: hide then show restores the native window; app stays running (tray use case).
- [ ] Games without the setting are unchanged.
