### PR TITLE
Keep Windows Xbox MSVC CI from starving the hosted runner

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -16,9 +16,10 @@ concurrency:
 
 jobs:
   build-windows:
-    # Xbox + MSVC /O2 + tests can OOM or starve windows-latest (2025) runners.
-    # Pin those jobs to windows-2022 and cap -j so the hosted agent keeps heartbeat.
-    runs-on: ${{ matrix.os || 'windows-latest' }}
+    # Windows 10 with latest image. Xbox jobs stay here because the Gaming GDK
+    # (and winget) are present; windows-2022 fails the GDK step. Cap Xbox SCons
+    # at -j2 so MSVC /O2 + tests do not starve the hosted runner.
+    runs-on: windows-latest
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:
@@ -100,7 +101,6 @@ jobs:
             bin: ./bin/blazium.windows.editor.tests.x86_64.exe
             compiler: msvc
             xbox_module_test: true
-            os: windows-2022
             cache-limit: 1
 
           - name: Template w/ Xbox Module (target=template_release, tests=yes, module_xbox_module_enabled=yes)
@@ -111,7 +111,6 @@ jobs:
             bin: ./bin/blazium.windows.template_release.tests.x86_64.exe
             compiler: msvc
             xbox_module_test: true
-            os: windows-2022
             cache-limit: 1
 
     steps:
@@ -158,6 +157,14 @@ jobs:
             "gdk_path=`"$EditionRoot`"" >> $env:GITHUB_ENV
           }
 
+          function Resolve-Winget {
+            $cmd = Get-Command winget -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            $winapps = Join-Path $env:LocalAppData 'Microsoft\WindowsApps\winget.exe'
+            if (Test-Path $winapps) { return $winapps }
+            return $null
+          }
+
           $editionRoot = Get-GdkEditionRoot
           if ($editionRoot) {
             Write-Host 'GDK already present; skipping winget install.'
@@ -165,17 +172,23 @@ jobs:
             exit 0
           }
 
-          Write-Host 'Repairing winget sources before GDK install...'
-          winget source disable msstore 2>$null
+          $winget = Resolve-Winget
+          if (-not $winget) {
+            Write-Error 'Microsoft Gaming GDK is not installed and winget is not available on this runner.'
+            exit 1
+          }
+
+          Write-Host "Repairing winget sources before GDK install ($winget)..."
+          & $winget source disable msstore 2>$null
           Import-Module Appx -UseWindowsPowerShell -ErrorAction SilentlyContinue
           Add-AppxPackage -Path "https://cdn.winget.microsoft.com/cache/source.msix" -ErrorAction SilentlyContinue
-          winget source update --accept-source-agreements
+          & $winget source update --accept-source-agreements
 
           $alreadyInstalledCodes = @(0, 2316632107, -1978335189)
           $maxAttempts = 3
           for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
             Write-Host "Installing Microsoft Gaming GDK via winget (attempt $attempt/$maxAttempts)..."
-            winget install --id Microsoft.Gaming.GDK `
+            & $winget install --id Microsoft.Gaming.GDK `
               --accept-package-agreements --accept-source-agreements --disable-interactivity
             $exitCode = $LASTEXITCODE
             if ($alreadyInstalledCodes -contains $exitCode) {

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -16,8 +16,9 @@ concurrency:
 
 jobs:
   build-windows:
-    # Windows 10 with latest image
-    runs-on: windows-latest
+    # Xbox + MSVC /O2 + tests can OOM or starve windows-latest (2025) runners.
+    # Pin those jobs to windows-2022 and cap -j so the hosted agent keeps heartbeat.
+    runs-on: ${{ matrix.os || 'windows-latest' }}
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:
@@ -99,6 +100,7 @@ jobs:
             bin: ./bin/blazium.windows.editor.tests.x86_64.exe
             compiler: msvc
             xbox_module_test: true
+            os: windows-2022
             cache-limit: 1
 
           - name: Template w/ Xbox Module (target=template_release, tests=yes, module_xbox_module_enabled=yes)
@@ -109,6 +111,7 @@ jobs:
             bin: ./bin/blazium.windows.template_release.tests.x86_64.exe
             compiler: msvc
             xbox_module_test: true
+            os: windows-2022
             cache-limit: 1
 
     steps:
@@ -226,11 +229,11 @@ jobs:
         if: matrix.xbox_module_test
         shell: cmd
         run: |
-          echo Building Xbox module with MSVC: platform=windows target=${{ matrix.target }} tests=${{ matrix.tests }} use_mingw=no ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          echo Building Xbox module with MSVC: platform=windows target=${{ matrix.target }} tests=${{ matrix.tests }} use_mingw=no ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} -j2 verbose=no
           if not "${{ matrix.target }}"=="editor" rmdir /s /q editor 2>nul
           if not "${{ github.event.number }}"=="" (set BUILD_NAME=gh-${{ github.event.number }}) else (set BUILD_NAME=gh)
           where cl
-          scons platform=windows target=${{ matrix.target }} tests=${{ matrix.tests }} use_mingw=no ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} "cache_path=${{ github.workspace }}/.scons_cache/" cache_limit=${{ matrix.cache-limit }}
+          scons platform=windows target=${{ matrix.target }} tests=${{ matrix.tests }} use_mingw=no ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} -j2 verbose=no "cache_path=${{ github.workspace }}/.scons_cache/" cache_limit=${{ matrix.cache-limit }}
           if errorlevel 1 exit /b 1
 
       - name: Compilation

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2682,6 +2682,7 @@
 			If [code]true[/code], allows hiding the main (root) window with [method Window.hide] or [member Window.visible]. When [code]false[/code] or unset, changing visibility of the main window is declined.
 			Enable this only for tools that need system-tray hide. Games should leave it off.
 			[b]Note:[/b] Hiding keeps the native window alive; it does not destroy [constant DisplayServer.MAIN_WINDOW_ID].
+			[b]Note:[/b] This setting is ignored on iOS, Android, and Web. Main-window hide/show is only implemented on Windows, Linux, and macOS.
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -881,6 +881,7 @@ void Window::set_visible(bool p_visible) {
 	}
 
 	if (!get_parent()) {
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
 		if (!GLOBAL_GET("display/window/size/allow_hide_main_window")) {
 			ERR_FAIL_MSG("Can't change visibility of main window.");
 		}
@@ -903,6 +904,9 @@ void Window::set_visible(bool p_visible) {
 		emit_signal(SceneStringName(visibility_changed));
 		RS::get_singleton()->viewport_set_active(get_viewport_rid(), visible);
 		return;
+#else
+		ERR_FAIL_MSG("Can't change visibility of main window.");
+#endif
 	}
 
 	visible = p_visible;


### PR DESCRIPTION
﻿## Summary
- The post-merge Xbox template job died mid-MSVC compile with a lost hosted runner. Cap Xbox SCons at `-j2` and disable verbose compile logs so the agent is not starved.
- Pinning Xbox jobs to `windows-2022` broke CI: that image has no Gaming GDK and no `winget` on PATH ([GDK install failed in 31s](https://github.com/blazium-games/blazium/actions/runs/34311582268/job/102339580236)). Keep Xbox jobs on `windows-latest` (GDK is preinstalled) and resolve `winget` from WindowsApps if a fallback install is needed.
- Main-window hide/show (`allow_hide_main_window`) is compile-gated to Windows, Linux, and macOS. iOS, Android, and Web keep the original "Can't change visibility of main window" error.

## Test plan
- [ ] Xbox editor and template jobs start on `windows-latest` and skip winget when GDK is already present
- [ ] Compilation (Xbox / MSVC) uses `-j2 verbose=no`
- [ ] Both Xbox jobs finish without runner-lost-communication or GDK install failure
- [ ] Other Windows matrix jobs are unchanged
- [ ] Android/iOS/Web still refuse hiding the main window even if the project setting is true
